### PR TITLE
Use Task.Delay instead of Thread.Sleep in BuffTask

### DIFF
--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -122,12 +122,12 @@ namespace XIVComboPlugin
                     seenNoUpdate.Remove(id);
             }
         }
-        private void BuffTask()
+        private async void BuffTask()
         {
             while (!shutdown)
             {
                 UpdateBuffAddress();
-                Thread.Sleep(1000);
+                await Task.Delay(1000);
             }
         }
 


### PR DESCRIPTION
Replace `Thread.Sleep(1000)` with `await Task.Delay(1000)` in `BuffTask()`. This seem to have solved the random pauses in my Sonar plugin, which is `Task` heavy.