### PR TITLE
NIN: Bunshin -> Phantom Kamaitachi

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -3,7 +3,7 @@ using XIVComboPlugin.JobActions;
 
 namespace XIVComboPlugin
 {
-    //CURRENT HIGHEST FLAG IS 56
+    //CURRENT HIGHEST FLAG IS 57
     [Flags]
     public enum CustomComboPreset : long
     {
@@ -81,6 +81,9 @@ namespace XIVComboPlugin
 
         [CustomComboInfo("Hakke Mujinsatsu Combo", "Replace Hakke Mujinsatsu with its combo chain", 30)]
         NinjaHakkeMujinsatsuCombo = 1L << 19,
+
+        [CustomComboInfo("Phantom Kamaitachi", "Replace Bunshin with Phantom Kamaitachi", 30)]
+        PhantomKamaitachiFeature = 1L << 57,
 
         // GUNBREAKER
         [CustomComboInfo("Solid Barrel Combo", "Replace Solid Barrel with its combo chain", 37)]

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -489,13 +489,17 @@ namespace XIVComboPlugin
 
             // Replace Bunshin with Phantom Kamaitachi
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PhantomKamaitachiFeature))
+            {
                 if (actionID == NIN.Bunshin)
+                {
                     if (level >= 82)
                     {
                         UpdateBuffAddress();
                         if (SearchBuffArray(NIN.BuffPhantomKamaitachiReady))
                             return NIN.PhantomKamaitachi;
                     }
+                }
+            }
 
             // GUNBREAKER
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -487,6 +487,16 @@ namespace XIVComboPlugin
                     return NIN.DeathBlossom;
                 }
 
+            // Replace Bunshin with Phantom Kamaitachi
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PhantomKamaitachiFeature))
+                if (actionID == NIN.Bunshin)
+                    if (level >= 82)
+                    {
+                        UpdateBuffAddress();
+                        if (SearchBuffArray(NIN.BuffPhantomKamaitachiReady))
+                            return NIN.PhantomKamaitachi;
+                    }
+
             // GUNBREAKER
 
             // Replace Solid Barrel with Solid Barrel combo

--- a/XIVComboPlugin/JobActions/NIN.cs
+++ b/XIVComboPlugin/JobActions/NIN.cs
@@ -10,6 +10,10 @@
             HakkeM = 16488,
             DeathBlossom = 2254,
             DWAD = 3566,
-            Assassinate = 2246;
+            Assassinate = 2246,
+            Bunshin = 16493,
+            PhantomKamaitachi = 25876;
+        public const short
+            BuffPhantomKamaitachiReady = 2723;
     }
 }


### PR DESCRIPTION
Replace Bunshin with Phantom Kamaitachi when Phantom Kamaitachi Ready buff is active.

I haven't been able to test this properly as SearchBuffArray is broken right now, but when mocking the buff search out it seems to function correctly.