### PR TITLE
RDM: Veraero/Thunder II -> Scatter/Impact for Acceleration

### DIFF
--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -949,7 +949,7 @@ namespace XIVComboPlugin
                 {
                     if (level >= 80 && (lastMove == RDM.Verflare || lastMove == RDM.Verholy)) return RDM.Scorch;
                     UpdateBuffAddress();
-                    if (SearchBuffArray(1235)) return RDM.Verstone;
+                    if (SearchBuffArray(RDM.BuffVerstoneReady)) return RDM.Verstone;
                     if (level < 62) return RDM.Jolt;
                     return RDM.Jolt2;
                 }
@@ -957,7 +957,7 @@ namespace XIVComboPlugin
                 {
                     if (level >= 80 && (lastMove == RDM.Verflare || lastMove == RDM.Verholy)) return RDM.Scorch;
                     UpdateBuffAddress();
-                    if (SearchBuffArray(1234)) return RDM.Verfire;
+                    if (SearchBuffArray(RDM.BuffVerfireReady)) return RDM.Verfire;
                     if (level < 62) return RDM.Jolt;
                     return RDM.Jolt2;
                 }

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -905,29 +905,18 @@ namespace XIVComboPlugin
 
             // RED MAGE
 
-            // Replace Veraero/thunder 2 with Impact when Dualcast is active
+            // Replace Veraero/Thunder 2 with Impact when Swiftcast, Acceleration or Dualcast are active.
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.RedMageAoECombo))
             {
-                if (actionID == RDM.Veraero2)
+                if (actionID == RDM.Verthunder2 || actionID == RDM.Veraero2)
                 {
                     UpdateBuffAddress();
-                    if (SearchBuffArray(167) || SearchBuffArray(1249))
+                    if (SearchBuffArray(RDM.BuffSwiftCast) || SearchBuffArray(RDM.BuffAcceleration) || SearchBuffArray(RDM.BuffDualCast))
                     {
                         if (level >= 66) return RDM.Impact;
                         return RDM.Scatter;
                     }
-                    return RDM.Veraero2;
-                }
-
-                if (actionID == RDM.Verthunder2)
-                {
-                    UpdateBuffAddress();
-                    if (SearchBuffArray(167) || SearchBuffArray(1249))
-                    {
-                        if (level >= 66) return RDM.Impact;
-                        return RDM.Scatter;
-                    }
-                    return RDM.Verthunder2;
+                    return actionID;
                 }
             }
 

--- a/XIVComboPlugin/JobActions/RDM.cs
+++ b/XIVComboPlugin/JobActions/RDM.cs
@@ -20,5 +20,9 @@
             Verholy = 7526,
             Verflare = 7525,
             Scorch = 16530;
+        public const short
+            BuffSwiftCast = 167, // Common for casters, but RDM is the only one using it currently.
+            BuffAcceleration = 1238,
+            BuffDualCast = 1249;
     }
 }

--- a/XIVComboPlugin/JobActions/RDM.cs
+++ b/XIVComboPlugin/JobActions/RDM.cs
@@ -22,6 +22,8 @@
             Scorch = 16530;
         public const short
             BuffSwiftCast = 167, // Common for casters, but RDM is the only one using it currently.
+            BuffVerfireReady = 1234,
+            BuffVerstoneReady = 1235,
             BuffAcceleration = 1238,
             BuffDualCast = 1249;
     }


### PR DESCRIPTION
Replace Veraero/Thunder II  with Scatter/Impact when Acceleration buff is active.

I haven't been able to test this properly as SearchBuffArray is broken right now, but when mocking the buff search out it seems to function correctly.

Should fix #127.