### PR TITLE
MCH: Rook Autoturret / Automaton Queen -> Rook/Queen Overdrive

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -3,7 +3,7 @@ using XIVComboPlugin.JobActions;
 
 namespace XIVComboPlugin
 {
-    //CURRENT HIGHEST FLAG IS 56
+    //CURRENT HIGHEST FLAG IS 57
     [Flags]
     public enum CustomComboPreset : long
     {
@@ -107,6 +107,9 @@ namespace XIVComboPlugin
 
         [CustomComboInfo("Heat Blast when overheated", "Replace Hypercharge with Heat Blast when overheated", 31)]
         MachinistOverheatFeature = 1L << 47,
+
+        [CustomComboInfo("Overdrive when robot active", "Replace either Rook Autoturrent or Automaton Queen with it's Overdrive when robot is active", 31)]
+        MachinistOverdriveFeature = 1L << 57,
 
         // BLACK MAGE
         [CustomComboInfo("Enochian Stance Switcher", "Change Fire 4 and Blizzard 4 to the appropriate element depending on stance", 25)]

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -598,6 +598,25 @@ namespace XIVComboPlugin
                     return MCH.Hypercharge;
                 }
 
+            // Replace Rook Autoturret and Automaton Queen with Rook Overdrive and Queen Overdrive when robot is active
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistOverheatFeature))
+            {
+                if (actionID == MCH.RookAutoturret)
+                {
+                    var gauge = XIVComboPlugin.JobGauges.Get<MCHGauge>();
+                    if (gauge.IsRobotActive)
+                        return MCH.RookOverdrive;
+                    return MCH.RookAutoturret;
+                }
+                else if (actionID == MCH.AutomatonQueen)
+                {
+                    var gauge = XIVComboPlugin.JobGauges.Get<MCHGauge>();
+                    if (gauge.IsRobotActive)
+                        return MCH.QueenOverdrive;
+                    return MCH.AutomatonQueen;
+                }
+            }
+
             // Replace Spread Shot with Auto Crossbow when overheated.
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistSpreadShotFeature))
                 if (actionID == MCH.SpreadShot)

--- a/XIVComboPlugin/JobActions/MCH.cs
+++ b/XIVComboPlugin/JobActions/MCH.cs
@@ -12,6 +12,10 @@
             Hypercharge = 17209,
             HeatBlast = 7410,
             SpreadShot = 2870,
-            AutoCrossbow = 16497;
+            AutoCrossbow = 16497,
+            RookAutoturret = 2864,
+            RookOverdrive = 7415,
+            AutomatonQueen = 16501,
+            QueenOverdrive = 16502;
     }
 }


### PR DESCRIPTION
Replaces Rook Autoturret and Automaton Queen with Rook Overdrive and Queen Overdrive when robot is active.

I actually have not tested the queen stuff as my MCH is not high level. This was something I made primarily for myself when I was doing some MCH leveling. Needs testing to make sure the queen stuff works, but logic is simple enough that I'm 99% sure it should.