### PR TITLE
BRD: Quick Knock/Ladonsbite -> Shadowbite

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -3,7 +3,7 @@ using XIVComboPlugin.JobActions;
 
 namespace XIVComboPlugin
 {
-    //CURRENT HIGHEST FLAG IS 56
+    //CURRENT HIGHEST FLAG IS 57
     [Flags]
     public enum CustomComboPreset : long
     {
@@ -165,6 +165,9 @@ namespace XIVComboPlugin
 
         [CustomComboInfo("Heavy Shot into Straight Shot", "Replaces Heavy Shot/Burst Shot with Straight Shot/Refulgent Arrow when procced", 23)]
         BardStraightShotUpgradeFeature = 1L << 42,
+
+        [CustomComboInfo("Quick Knock into Shadowbite", "Replaces Quick Knock/Ladonsbite with Shadowbite when procced", 23)]
+        BardQuickNockUpgradeFeature = 1L << 57,
 
         // MONK
         [CustomComboInfo("Monk AoE Combo", "Replaces Rockbreaker with the AoE combo chain, or Rockbreaker when Perfect Balance is active", 20)]

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -880,7 +880,7 @@ namespace XIVComboPlugin
                 if (actionID == BRD.HeavyShot || actionID == BRD.BurstShot)
                 {
                     UpdateBuffAddress();
-                    if (SearchBuffArray(122))
+                    if (SearchBuffArray(BRD.BuffStraightShotReady))
                     {
                         if (level >= 70) return BRD.RefulgentArrow;
                         return BRD.StraightShot;
@@ -889,6 +889,19 @@ namespace XIVComboPlugin
                     if (level >= 76) return BRD.BurstShot;
                     return BRD.HeavyShot;
                 }
+
+            // Replace Quick Knock/Ladonsbite with Shadowbite when procced.
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BardQuickNockUpgradeFeature))
+            {
+                if (actionID == BRD.QuickKnock || actionID == BRD.Ladonsbite)
+                {
+                    UpdateBuffAddress();
+                    if (SearchBuffArray(BRD.BuffShadowbiteReady))
+                        return BRD.Shadowbite;
+
+                    return actionID;
+                }
+            }
 
             // MONK
 

--- a/XIVComboPlugin/JobActions/BRD.cs
+++ b/XIVComboPlugin/JobActions/BRD.cs
@@ -8,6 +8,12 @@
             HeavyShot = 97,
             BurstShot = 16495,
             StraightShot = 98,
-            RefulgentArrow = 7409;
+            RefulgentArrow = 7409,
+            QuickKnock = 106,
+            Ladonsbite = 25783,
+            Shadowbite = 16494;
+        public const short
+            BuffStraightShotReady = 122,
+            BuffShadowbiteReady = 3002;
     }
 }


### PR DESCRIPTION
Replaces Quick Knock/Ladonsbite with Shadowbite when Shadowbite Ready buff is active. Fixes #132.