### PR TITLE
RPR: Arcane Circle -> Plentiful Harvest & Enshroud -> Communio

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -3,7 +3,7 @@ using XIVComboPlugin.JobActions;
 
 namespace XIVComboPlugin
 {
-    //CURRENT HIGHEST FLAG IS 57
+    //CURRENT HIGHEST FLAG IS 58
     [Flags]
     public enum CustomComboPreset : long
     {
@@ -189,6 +189,9 @@ namespace XIVComboPlugin
 
         [CustomComboInfo("Arcane Circle into Plentiful Harvest", "Replace Arcane Circle with Plentiful Harvest when Circle of Sacrifice or Immortal Sacrifice are active.", 39)]
         ReaperPlentifulHarvestFeature = 1L << 57,
+
+        [CustomComboInfo("Enshroud into Communio", "Replace Enshroud with Communio when Enshrouded is active.", 39)]
+        ReaperCommunioFeature = 1L << 58,
     }
 
     public class CustomComboInfoAttribute : Attribute

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -3,7 +3,7 @@ using XIVComboPlugin.JobActions;
 
 namespace XIVComboPlugin
 {
-    //CURRENT HIGHEST FLAG IS 56
+    //CURRENT HIGHEST FLAG IS 57
     [Flags]
     public enum CustomComboPreset : long
     {
@@ -180,11 +180,15 @@ namespace XIVComboPlugin
         [CustomComboInfo("Verproc into Jolt", "Replaces Verstone/Verfire with Jolt/Scorch when no proc is available.", 35)]
         RedMageVerprocCombo = 1L << 53,
 
+        // REAPER
         [CustomComboInfo("Slice Combo", "Replace Slice with its combo chain.", 39)]
         ReaperSliceCombo = 1L << 16,
 
         [CustomComboInfo("Scythe Combo", "Replace Spinning Scythe with its combo chain.", 39)]
         ReaperScytheCombo = 1L << 17,
+
+        [CustomComboInfo("Arcane Circle into Plentiful Harvest", "Replace Arcane Circle with Plentiful Harvest when Circle of Sacrifice or Immortal Sacrifice are active.", 39)]
+        ReaperPlentifulHarvestFeature = 1L << 57,
     }
 
     public class CustomComboInfoAttribute : Attribute

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -1012,7 +1012,7 @@ namespace XIVComboPlugin
             {
                 if (actionID == RPR.ArcaneCircle)
                 {
-                    if(level == RPR.Levels.PlentifulHarvest) { 
+                    if(level >= RPR.Levels.PlentifulHarvest) { 
                         UpdateBuffAddress();
                         if (SearchBuffArray(RPR.Buffs.CircleOfSacrifice) || SearchBuffArray(RPR.Buffs.ImmortalSacrifice))
                             return RPR.PlentifulHarvest;
@@ -1026,7 +1026,7 @@ namespace XIVComboPlugin
             {
                 if (actionID == RPR.Enshroud)
                 {
-                    if (level == RPR.Levels.Communio)
+                    if (level >= RPR.Levels.Communio)
                     {
                         UpdateBuffAddress();
                         if (SearchBuffArray(RPR.Buffs.Enshrouded))

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -1005,8 +1005,20 @@ namespace XIVComboPlugin
 
                     return RPR.SpinningScythe;
                 }
+            }
 
-                return actionID;
+            // Replace Arcane Circle with Plentiful Harvest when Circle of Sacrifice or Immortal Sacrifice are active.
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperPlentifulHarvestFeature))
+            {
+                if (actionID == RPR.ArcaneCircle)
+                {
+                    if(level == RPR.Levels.PlentifulHarvest) { 
+                        UpdateBuffAddress();
+                        if (SearchBuffArray(RPR.Buffs.CircleOfSacrifice) || SearchBuffArray(RPR.Buffs.ImmortalSacrifice))
+                            return RPR.PlentifulHarvest;
+                    }
+                    return actionID;
+                }
             }
 
             return iconHook.Original(self, actionID);

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -1021,6 +1021,21 @@ namespace XIVComboPlugin
                 }
             }
 
+            // Replace Enshroud with Communio when Enshrouded is active.
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperCommunioFeature))
+            {
+                if (actionID == RPR.Enshroud)
+                {
+                    if (level == RPR.Levels.Communio)
+                    {
+                        UpdateBuffAddress();
+                        if (SearchBuffArray(RPR.Buffs.Enshrouded))
+                            return RPR.Communio;
+                    }
+                    return actionID;
+                }
+            }
+
             return iconHook.Original(self, actionID);
         }
         /*

--- a/XIVComboPlugin/JobActions/RPR.cs
+++ b/XIVComboPlugin/JobActions/RPR.cs
@@ -12,19 +12,24 @@
             // AoE
             SpinningScythe = 24376,
             NightmareScythe = 24377,
+            PlentifulHarvest = 24385,
             // Shroud
             Enshroud = 24394,
-            Communio = 24398;
+            Communio = 24398,
+            // Buffs
+            ArcaneCircle = 24405;
 
         public static class Buffs
         {
-            public const ushort
-                Enshrouded = 2593;
+            public const short
+                Enshrouded = 2593,
+                ImmortalSacrifice = 2592,
+                CircleOfSacrifice = 2600;
         }
 
         public static class Debuffs
         {
-            public const ushort
+            public const short
                 Placeholder = 0;
         }
 
@@ -37,6 +42,7 @@
                 InfernalSlice = 30,
                 NightmareScythe = 45,
                 Enshroud = 80,
+                PlentifulHarvest = 88,
                 Communio = 90;
         }
     }


### PR DESCRIPTION
Replace Arcane Circle with Plentiful Harvest when Circle of Sacrifice or Immortal Sacrifice are active.
Replace Enshroud with Communio when Enshrouded is active.

Not able properly due to my build's buff checking still not functioning.

Resolves #142 and a portion of #113.