### PR TITLE
PLD: Replace Requiescat with Holy Spirit when below level 80

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -42,7 +42,7 @@ namespace XIVComboPlugin
         [CustomComboInfo("Prominence Combo", "Replace Prominence with its combo chain", 19, new uint[] { PLD.Prominence })]
         PaladinProminenceCombo = 1L << 7,
 
-        [CustomComboInfo("Requiescat Confiteor", "Replace Requiescat with Confiter while under the effect of Requiescat", 19, new uint[] { PLD.Requiescat })]
+        [CustomComboInfo("Requiescat Confiteor", "Replace Requiescat with Confiteor/Holy Spirit while under the effect of Requiescat", 19, new uint[] { PLD.Requiescat })]
         PaladinRequiescatCombo = 1L << 55,
 
         // WARRIOR

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -343,12 +343,18 @@ namespace XIVComboPlugin
                     return PLD.TotalEclipse;
                 }
             
-            // Replace Requiescat with Confiteor when under the effect of Requiescat
+            // Replace Requiescat with Confiteor/Holy Spirit when under the effect of Requiescat
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinRequiescatCombo))
                 if (actionID == PLD.Requiescat)
                 {
-                    if (SearchBuffArray(1368) && level >= 80)
-                        return PLD.Confiteor;
+                    if (SearchBuffArray(1368))
+                    {
+                        if (level >= 80)
+                            return PLD.Confiteor;
+                        else if (level >= 64)
+                            return PLD.HolySpirit;
+                    }
+                    
                     return PLD.Requiescat;
                 }
 

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -11,6 +11,7 @@
             Prominence = 16457,
             TotalEclipse = 7381,
             Requiescat = 7383,
+            HolySpirit = 7384,
             Confiteor = 16459;
     }
 }


### PR DESCRIPTION
Currently, the plugin only allows replacing Requiescat with Confiteor. Unfortunately, Confiteor only works for characters with level 80+. I made some small changes to allow the plugin to replace Requiescat with Holy Spirit for characters with level 68-79.

Holy Spirit is available as of level 64 which is why the code is written that way, even if Requiescat itself is only available as of level 68.

I also fixed a small mistake in the configuration description for this combo: "Confiter" -> "Confiteor".