### PR TITLE
Add Atonement to the PLD Royal Authority / Rage of Halone combo

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -32,7 +32,7 @@ namespace XIVComboPlugin
         [CustomComboInfo("Goring Blade Combo", "Replace Goring Blade with its combo chain", 19)]
         PaladinGoringBladeCombo = 1L << 5,
 
-        [CustomComboInfo("Royal Authority Combo", "Replace Royal Authority/Rage of Halone with its combo chain", 19)]
+        [CustomComboInfo("Royal Authority Combo", "Replace Royal Authority/Rage of Halone with its combo chain, including Atonement", 19)]
         PaladinRoyalAuthorityCombo = 1L << 6,
 
         [CustomComboInfo("Prominence Combo", "Replace Prominence with its combo chain", 19)]

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -218,6 +218,9 @@ namespace XIVComboPlugin
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinRoyalAuthorityCombo))
                 if (actionID == PLD.RoyalAuthority || actionID == PLD.RageOfHalone)
                 {
+                    if (SearchBuffArray(1902) && level >= 76)
+                        return PLD.Atonement;
+
                     if (comboTime > 0)
                     {
                         if (lastMove == PLD.FastBlade && level >= 4)

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -14,6 +14,7 @@
             Confiteor = 16459,
             BladeOfFaith = 25748,
             BladeOfTruth = 25749,
-            BladeOfValor = 25750;
+            BladeOfValor = 25750,
+            Atonement = 16460;
     }
 }


### PR DESCRIPTION
Would close #30 (not by me).

The logic is this:
1. Is the buff *Sword Oath* up?
2. Is the character level >=76
3. If yes, return Atonement before checking for the other skills.

This seems to fit the requirements for a combo request:
* While the existing combo *can* be used when Sword Oath is up, the only reason to want to start it again before using up any remaining Sword Oath charges would be to apply the DoT, but that is already a separate Goring Blade combo and hence is a separate button on the hotbar anyways.
* There is no other use case for Atonement on the hotbar as it is deactivated without Sword Oath being up. 
* This mirrors how Paladins think about their two main physical attack sequences: Either apply a DoT via Fast -> Riot -> Goring or when that is up, use Fast -> Riot -> Royal -> Atonement(x3) for maximum damage and more mana regen.
* It's dead simple from an intelligence POV: If you got Sword Oath up, you want to press Atonement. If you don't, you want to do the Royal Authority combo to get Sword Oath up.

(If I forgot anything I am truly sorry, this is the first time I'm creating a pull request for this plugin, just let me know!)