### PR TITLE
Added Veraero and Verthunder to the RDM Combos

### DIFF
--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -868,7 +868,14 @@ namespace XIVComboPlugin
                     if (level >= 80 && (lastMove == RDM.Verflare || lastMove == RDM.Verholy)) return RDM.Scorch;
                     if (level >= 90 && lastMove == RDM.Scorch) return RDM.Resolution;
 
+                    if (SearchBuffArray(167) || SearchBuffArray(1249) || SearchBuffArray(1238))
+                    {
+                        if (level >= 82) return RDM.Veraero3;
+                        return RDM.Veraero;
+                    }
+
                     if (SearchBuffArray(1235)) return RDM.Verstone;
+
                     if (level < 62) return RDM.Jolt;
                     return RDM.Jolt2;
                 }
@@ -876,6 +883,12 @@ namespace XIVComboPlugin
                 {
                     if (level >= 80 && (lastMove == RDM.Verflare || lastMove == RDM.Verholy)) return RDM.Scorch;
                     if (level >= 90 && lastMove == RDM.Scorch) return RDM.Resolution;
+
+                    if (SearchBuffArray(167) || SearchBuffArray(1249) || SearchBuffArray(1238))
+                    {
+                        if (level >= 82) return RDM.Verthunder3;
+                        return RDM.Verthunder;
+                    }
 
                     if (SearchBuffArray(1234)) return RDM.Verfire;
                     if (level < 62) return RDM.Jolt;

--- a/XIVComboPlugin/JobActions/RDM.cs
+++ b/XIVComboPlugin/JobActions/RDM.cs
@@ -3,8 +3,12 @@
     public static class RDM
     {
         public const uint
+            Veraero = 7507,
+            Verthunder = 7505,
             Veraero2 = 16525,
             Verthunder2 = 16524,
+            Veraero3 = 25856,
+            Verthunder3 = 25855,
             Impact = 16526,
             Redoublement = 7516,
             ERedoublement = 7529,


### PR DESCRIPTION
This modification is trying to turn the Jolt combos into a 1, 2, 3 combo since it seems like only adding one small step.