### PR TITLE
Nin/armor crush low lv fallback

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -81,7 +81,7 @@ namespace XIVComboPlugin
         [CustomComboInfo("Bunshin Combo", "Replace Bunshin with Phantom Kamaitachi when Phantom Kamaitachi Ready", 30)]
         NinjaBunshinCombo = 1L << 58,
 
-        [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain", 30)]
+        [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain (substituted with Aeolian Edge at lower levels)", 30)]
         NinjaArmorCrushCombo = 1L << 17,
 
         [CustomComboInfo("Aeolian Edge Combo", "Replace Aeolian Edge with its combo chain", 30)]

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -431,6 +431,9 @@ namespace XIVComboPlugin
                             return NIN.GustSlash;
                         if (lastMove == NIN.GustSlash && level >= 54)
                             return NIN.ArmorCrush;
+                        // For levels 26 ~ 53, continue combo via Aeolian since Armor Crush isn't available yet
+                        if (lastMove == NIN.GustSlash && level >= 26)
+                            return NIN.AeolianEdge;
                     }
 
                     return NIN.SpinningEdge;


### PR DESCRIPTION
Summary: QoL enhancement for NIN Armor Crush at lower levels

Issue being solved: between levels 26~53, Armor Crush isn't available on NIN yet. So when the option is enabled, the combo chain cycles between Spinning Edge > Gust Slash. But this is never optimal because it skips over Aeolian Edge.
This is a small QoL enhancement that puts Aeolian Edge on the Armor Crush key when the latter isn't unlocked yet.

Sanity checks, per #119 
1. Mutually exclusive? Yes, because this only applies before Armor Crush is unlocked
2. Saves buttons? Not directly, although it complements the existing chain
3. Easy to use? Yes, since it's always more optimal