### PR TITLE
NIN: Add Huraijin into Aeolian Edge/Armor Crush combo chains

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -90,6 +90,9 @@ namespace XIVComboPlugin
         [CustomComboInfo("Hakke Mujinsatsu Combo", "Replace Hakke Mujinsatsu with its combo chain", 30)]
         NinjaHakkeMujinsatsuCombo = 1L << 19,
 
+        [CustomComboInfo("Auto Huraijin", "Add Huraijin in Armor Crush/Aeolian Edge combos when Huton is inactive. (Requires respective combos enabled to take effect.)", 30)]
+        NinjaAutoHuraijin = 1L << 31,
+
         // GUNBREAKER
         [CustomComboInfo("Solid Barrel Combo", "Replace Solid Barrel with its combo chain", 37)]
         GunbreakerSolidBarrelCombo = 1L << 20,

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -425,6 +425,15 @@ namespace XIVComboPlugin
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaArmorCrushCombo))
                 if (actionID == NIN.ArmorCrush)
                 {
+                    if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaAutoHuraijin))
+                    {
+                        var gauge = XIVComboPlugin.JobGauges.Get<NINGauge>();
+                        if (gauge.HutonTimer <= 0 && level >= 60)
+                        {
+                            return NIN.Huraijin;
+                        }
+                    }
+
                     if (comboTime > 0)
                     {
                         if (lastMove == NIN.SpinningEdge && level >= 4)
@@ -440,6 +449,15 @@ namespace XIVComboPlugin
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaAeolianEdgeCombo))
                 if (actionID == NIN.AeolianEdge)
                 {
+                    if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaAutoHuraijin))
+                    {
+                        var gauge = XIVComboPlugin.JobGauges.Get<NINGauge>();
+                        if (gauge.HutonTimer <= 0 && level >= 60)
+                        {
+                            return NIN.Huraijin;
+                        }
+                    }
+
                     if (comboTime > 0)
                     {
                         if (lastMove == NIN.SpinningEdge && level >= 4)

--- a/XIVComboPlugin/JobActions/NIN.cs
+++ b/XIVComboPlugin/JobActions/NIN.cs
@@ -12,6 +12,7 @@
             DWAD = 3566,
             Assassinate = 2246,
             Bunshin = 16493,
-            PhantomK = 25774;
+            PhantomK = 25774,
+            Huraijin = 25876;
     }
 }


### PR DESCRIPTION
Summary: New option to add Huraijin into the basic Aeolian Edge / Armor Crush GCD combos

Sanity checks, per #119
1. Exclusivity: I would say this works in about 95% of scenarios and would be comfier for most users. But because it's not completely airtight, I put it behind a flag so users are able to toggle it on/off at will as they prefer.
- For an optimal rotation, Huraijin never appears in the first place because Huton is always refreshed with Armor Crush
- If Huton gets dropped, the typical play is to restore it asap
- The main scenario this wouldn't be optimal for would be around last hits/boss downtime, where it would be slightly more potency to make the final hits with regular GCDs without Huton

2. Button space saving: Yes, Huraijin no longer needs to be mapped

3. Ease of use: Very easy. Just play as usual but now you'll never drop Huton