### PR TITLE
Royalauthority to atonement

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -32,6 +32,9 @@ namespace XIVComboPlugin
         [CustomComboInfo("Royal Authority Combo", "Replace Royal Authority/Rage of Halone with its combo chain", 19)]
         PaladinRoyalAuthorityCombo = 1L << 6,
 
+        [CustomComboInfo("Royal Authority to Atonement", "Replace Royal Authority with Atonement if any Sword Oath stacks are present", 19)]
+        PaladinAtonementCombo = 1L << 64,
+
         [CustomComboInfo("Prominence Combo", "Replace Prominence with its combo chain", 19)]
         PaladinProminenceCombo = 1L << 7,
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -208,7 +208,7 @@ namespace XIVComboPlugin
             // Replace Royal Authority with Atonement if any Sword Oath stacks are present
             //     This check comes before Royal Authority combo, as we want to prioritize Atonement for this combo if there's any sword oath stacks present
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinAtonementCombo))
-                if ((actionID == PLD.RoyalAuthority || actionID == PLD.RageOfHalone) && SearchBuffArray(PLD.SwordOath))
+                if ((actionID == PLD.RoyalAuthority || actionID == PLD.RageOfHalone) && SearchBuffArray(PLD.BuffSwordOath))
                     return PLD.Atonement;
 
             // Replace Royal Authority with Royal Authority combo

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -205,6 +205,12 @@ namespace XIVComboPlugin
                     return PLD.FastBlade;
                 }
 
+            // Replace Royal Authority with Atonement if any Sword Oath stacks are present
+            //     This check comes before Royal Authority combo, as we want to prioritize Atonement for this combo if there's any sword oath stacks present
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinAtonementCombo))
+                if ((actionID == PLD.RoyalAuthority || actionID == PLD.RageOfHalone) && SearchBuffArray(PLD.SwordOath))
+                    return PLD.Atonement;
+
             // Replace Royal Authority with Royal Authority combo
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinRoyalAuthorityCombo))
                 if (actionID == PLD.RoyalAuthority || actionID == PLD.RageOfHalone)

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -8,6 +8,7 @@
             RiotBlade = 15,
             RoyalAuthority = 3539,
             RageOfHalone = 21,
+            Atonement = 16460,
             Prominence = 16457,
             TotalEclipse = 7381,
             Requiescat = 7383,
@@ -18,6 +19,8 @@
 
         public const short
             BuffRequiescat = 1368,
-            BuffBladeOfFaithReady = 3019;
+            BuffBladeOfFaithReady = 3019,
+            //Can be either 1902 or 1991 - it looks like 1991 is the PVP variant, and was added in 6.1
+            BuffSwordOath = 1902;
     }
 }


### PR DESCRIPTION
This PR is to add a new combo option for Paladin, where Royal Authority is replaced with Atonement in the event that any Sword Oath stacks are remaining on the player.
- It's important to note that this doesn't conflict with the existing 'Royal Authority' combo, as it is checked before it goes into that logic. And if there are no sword oath stacks on the player, then it falls through into the existing Royal Authority combo check.

## Sanity Checks

- [ ] The abilities in question must be truly mutually exclusive. If you can use A, there is literally no way to use B, and vice versa.
  - Caveat: If this isn't technically true, you need to have solid proof that there is NO contrived scenario in which you want to do things in a different way.

While Atonement and the Royal Authority combo aren't mutually exclusive, there's no reason to initiate a combo with Royal Authority while the user has any Sword Oath stacks remaining. 
- Executing Atonement drops your combo, so you can't "prep" a Royal Authority ahead of time.
- If you want to use Goring Blade (which uses the same step 1/2) while you have sword oath stacks, then you won't be pressing the Royal Authority button to do it.

----

- [ ] It actually saves you button space. 
  - Turning Inner Release into Fell Cleave when IR is active saves you no button spaces, because you need to press FC outside of IR anyways.

This eliminates the need for an 'Atonement' button on your bar. It's not possible to execute Atonement without Sword Oath stacks, and we've already established that there's no reason to execute Royal Authority while any Sword Oath stacks are remaining.

----

- [ ] It isn't wild and wacky, and the overall level of intelligence required to execute is about as low as the floor.

The idea was not only simple to implement, but I believe it's simple to understand as well. I added this in around an hour - and most of that was trying to reverse engineer how y'all added the existing combos. 😂