### PR TITLE
Add really basic scale factor

### DIFF
--- a/XIVComboPlugin/packages.lock.json
+++ b/XIVComboPlugin/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.13, )",
-        "resolved": "2.1.13",
-        "contentHash": "rMN1omGe8536f4xLMvx9NwfvpAc9YFFfeXJ1t4P4PE6Gu8WCIoFliR1sh07hM+bfODmesk/dvMbji7vNI+B/pQ=="
+        "requested": "[11.0.0, )",
+        "resolved": "11.0.0",
+        "contentHash": "bjT7XUlhIJSmsE/O76b7weUX+evvGQctbQB8aKXt94o+oPWxHpCepxAGMs7Thow3AzCyqWs7cOpp9/2wcgRRQA=="
       }
     }
   }


### PR DESCRIPTION
I stole this method from SimpleTweaks. Grabs the scale factor that's set and applies it to some of the UI so XIVCombo no longer cuts off the save/save and close buttons if people have a large scale factor.

Also adjusted two of the hint paths from assumed locations to %appdata%