### PR TITLE
Allow more than 63 combo configs to be stored

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -2,195 +2,191 @@
 
 namespace XIVComboPlugin
 {
-    //TODO: reorganize the numbers lol lmao
-    [Flags]
     public enum CustomComboPreset : long
     {
-        None = 0,
-
         // DRAGOON
         [CustomComboInfo("Jump + Mirage Dive", "Replace (High) Jump with Mirage Dive when Dive Ready", 22)]
-        DragoonJumpFeature = 1L << 44,
+        DragoonJumpFeature = 44,
 
         [CustomComboInfo("Coerthan Torment Combo", "Replace Coerthan Torment with its combo chain", 22)]
-        DragoonCoerthanTormentCombo = 1L << 0,
+        DragoonCoerthanTormentCombo = 0,
 
         [CustomComboInfo("Chaos Thrust Combo", "Replace Chaos Thrust with its combo chain", 22)]
-        DragoonChaosThrustCombo = 1L << 1,
+        DragoonChaosThrustCombo = 1,
 
         [CustomComboInfo("Full Thrust Combo", "Replace Full Thrust with its combo chain", 22)]
-        DragoonFullThrustCombo = 1L << 2,
+        DragoonFullThrustCombo = 2,
 
         // DARK KNIGHT
         [CustomComboInfo("Souleater Combo", "Replace Souleater with its combo chain", 32)]
-        DarkSouleaterCombo = 1L << 3,
+        DarkSouleaterCombo = 3,
 
         [CustomComboInfo("Stalwart Soul Combo", "Replace Stalwart Soul with its combo chain", 32)]
-        DarkStalwartSoulCombo = 1L << 4,
+        DarkStalwartSoulCombo = 4,
 
         // PALADIN
         [CustomComboInfo("Royal Authority Combo", "Replace Royal Authority/Rage of Halone with its combo chain", 19)]
-        PaladinRoyalAuthorityCombo = 1L << 6,
+        PaladinRoyalAuthorityCombo = 6,
 
         [CustomComboInfo("Prominence Combo", "Replace Prominence with its combo chain", 19)]
-        PaladinProminenceCombo = 1L << 7,
+        PaladinProminenceCombo = 7,
 
         [CustomComboInfo("Requiescat Confiteor", "Replace Requiescat with Confiteor while under the effect of Requiescat", 19)]
-        PaladinRequiescatCombo = 1L << 55,
+        PaladinRequiescatCombo = 55,
 
         // WARRIOR
         [CustomComboInfo("Storms Path Combo", "Replace Storms Path with its combo chain", 21)]
-        WarriorStormsPathCombo = 1L << 8,
+        WarriorStormsPathCombo = 8,
 
         [CustomComboInfo("Storms Eye Combo", "Replace Storms Eye with its combo chain", 21)]
-        WarriorStormsEyeCombo = 1L << 9,
+        WarriorStormsEyeCombo = 9,
 
         [CustomComboInfo("Mythril Tempest Combo", "Replace Mythril Tempest with its combo chain", 21)]
-        WarriorMythrilTempestCombo = 1L << 10,
+        WarriorMythrilTempestCombo = 10,
 
         [CustomComboInfo("IR to Primal Rend", "Replace Inner Release with Primal Rend when Primal Rend Ready", 21)]
-        WarriorIRCombo = 1L << 63,
+        WarriorIRCombo = 63,
 
         // SAMURAI
         [CustomComboInfo("Yukikaze Combo", "Replace Yukikaze with its combo chain", 34)]
-        SamuraiYukikazeCombo = 1L << 11,
+        SamuraiYukikazeCombo = 11,
 
         [CustomComboInfo("Gekko Combo", "Replace Gekko with its combo chain", 34)]
-        SamuraiGekkoCombo = 1L << 12,
+        SamuraiGekkoCombo = 12,
 
         [CustomComboInfo("Kasha Combo", "Replace Kasha with its combo chain", 34)]
-        SamuraiKashaCombo = 1L << 13,
+        SamuraiKashaCombo = 13,
 
         [CustomComboInfo("Mangetsu Combo", "Replace Mangetsu with its combo chain", 34)]
-        SamuraiMangetsuCombo = 1L << 14,
+        SamuraiMangetsuCombo = 14,
 
         [CustomComboInfo("Oka Combo", "Replace Oka with its combo chain", 34)]
-        SamuraiOkaCombo = 1L << 15,
+        SamuraiOkaCombo = 15,
 
         [CustomComboInfo("Iaijutsu into Tsubame", "Replace Iaijutsu with Tsubame after using an Iaijutsu", 34)]
-        SamuraiTsubameCombo = 1L << 56,
+        SamuraiTsubameCombo = 56,
 
         [CustomComboInfo("Ogi Namikiri Combo", "Replace Ikishoten with Ogi Namiki and Kaeshi Namikiri when appropriate", 34)]
-        SamuraiOgiCombo = 1L << 62,
+        SamuraiOgiCombo = 62,
 
 
         // NINJA
         [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain", 30)]
-        NinjaArmorCrushCombo = 1L << 17,
+        NinjaArmorCrushCombo = 17,
 
         [CustomComboInfo("Aeolian Edge Combo", "Replace Aeolian Edge with its combo chain", 30)]
-        NinjaAeolianEdgeCombo = 1L << 18,
+        NinjaAeolianEdgeCombo = 18,
 
         [CustomComboInfo("Hakke Mujinsatsu Combo", "Replace Hakke Mujinsatsu with its combo chain", 30)]
-        NinjaHakkeMujinsatsuCombo = 1L << 19,
+        NinjaHakkeMujinsatsuCombo = 19,
 
         // GUNBREAKER
         [CustomComboInfo("Solid Barrel Combo", "Replace Solid Barrel with its combo chain", 37)]
-        GunbreakerSolidBarrelCombo = 1L << 20,
+        GunbreakerSolidBarrelCombo = 20,
 
         [CustomComboInfo("Wicked Talon Combo", "Replace Wicked Talon with its combo chain", 37)]
-        GunbreakerGnashingFangCombo = 1L << 21,
+        GunbreakerGnashingFangCombo = 21,
 
         [CustomComboInfo("Wicked Talon Continuation", "In addition to the Wicked Talon combo chain, put Continuation moves on Wicked Talon when appropriate", 37)]
-        GunbreakerGnashingFangCont = 1L << 52,
+        GunbreakerGnashingFangCont = 52,
 
         [CustomComboInfo("Burst Strike Continuation", "Put Continuation moves on Burst Strike when appropriate", 37)]
-        GunbreakerBurstStrikeCont = 1L << 45,
+        GunbreakerBurstStrikeCont = 45,
 
         [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain", 37)]
-        GunbreakerDemonSlaughterCombo = 1L << 22,
+        GunbreakerDemonSlaughterCombo = 22,
 
         // MACHINIST
         [CustomComboInfo("(Heated) Shot Combo", "Replace either form of Clean Shot with its combo chain", 31)]
-        MachinistMainCombo = 1L << 23,
+        MachinistMainCombo = 23,
 
         [CustomComboInfo("Spread Shot Heat", "Replace Spread Shot or Scattergun with Auto Crossbow when overheated", 31)]
-        MachinistSpreadShotFeature = 1L << 24,
+        MachinistSpreadShotFeature = 24,
 
         [CustomComboInfo("Heat Blast when overheated", "Replace Hypercharge with Heat Blast when overheated", 31)]
-        MachinistOverheatFeature = 1L << 47,
+        MachinistOverheatFeature = 47,
 
         // BLACK MAGE
         [CustomComboInfo("Enochian Stance Switcher", "Change Fire 4 and Blizzard 4 to the appropriate element depending on stance, as well as Flare and Freeze", 25)]
-        BlackEnochianFeature = 1L << 25,
+        BlackEnochianFeature = 25,
 
         [CustomComboInfo("(Between the) Ley Lines", "Change Ley Lines into BTL when Ley Lines is active", 25)]
-        BlackLeyLines = 1L << 28,
+        BlackLeyLines = 28,
 
         // ASTROLOGIAN
         [CustomComboInfo("Draw on Play", "Play turns into Draw when no card is drawn, as well as the usual Play behavior", 33)]
-        AstrologianCardsOnDrawFeature = 1L << 27,
+        AstrologianCardsOnDrawFeature = 27,
 
         // SUMMONER
 
         [CustomComboInfo("ED Fester", "Change Fester into Energy Drain when out of Aetherflow stacks", 27)]
-        SummonerEDFesterCombo = 1L << 39,
+        SummonerEDFesterCombo = 39,
 
         [CustomComboInfo("ES Painflare", "Change Painflare into Energy Syphon when out of Aetherflow stacks", 27)]
-        SummonerESPainflareCombo = 1L << 40,
+        SummonerESPainflareCombo = 40,
         
         // SCHOLAR
         [CustomComboInfo("Seraph Fey Blessing/Consolation", "Change Fey Blessing into Consolation when Seraph is out", 28)]
-        ScholarSeraphConsolationFeature = 1L << 29,
+        ScholarSeraphConsolationFeature = 29,
 
         [CustomComboInfo("ED Aetherflow", "Change Energy Drain into Aetherflow when you have no more Aetherflow stacks", 28)]
-        ScholarEnergyDrainFeature = 1L << 37,
+        ScholarEnergyDrainFeature = 37,
 
         // DANCER
         [CustomComboInfo("AoE GCD procs", "DNC AoE procs turn into their normal abilities when not procced", 38)]
-        DancerAoeGcdFeature = 1L << 32,
+        DancerAoeGcdFeature = 32,
 
         [CustomComboInfo("Fan Dance Combos", "Change Fan Dance and Fan Dance 2 into Fan Dance 3 while flourishing", 38)]
-        DancerFanDanceCombo = 1L << 33,
+        DancerFanDanceCombo = 33,
 
         [CustomComboInfo("Fan Dance IV", "Change Flourish into Fan Dance IV while flourishing", 38)]
-        DancerFanDance4Combo = 1L << 60,
+        DancerFanDance4Combo = 60,
 
         [CustomComboInfo("Devilment into Starfall", "Change Devilment into Starfall Dance while under the effect of Flourishing Starfall", 38)]
-        DancerDevilmentCombo = 1L << 61,
+        DancerDevilmentCombo = 61,
 
         // WHITE MAGE
         [CustomComboInfo("Solace into Misery", "Replaces Afflatus Solace with Afflatus Misery when Misery is ready to be used", 24)]
-        WhiteMageSolaceMiseryFeature = 1L << 35,
+        WhiteMageSolaceMiseryFeature = 35,
 
         [CustomComboInfo("Rapture into Misery", "Replaces Afflatus Rapture with Afflatus Misery when Misery is ready to be used", 24)]
-        WhiteMageRaptureMiseryFeature = 1L << 36,
+        WhiteMageRaptureMiseryFeature = 36,
 
         // BARD
         [CustomComboInfo("Heavy Shot into Straight Shot", "Replaces Heavy Shot/Burst Shot with Straight Shot/Refulgent Arrow when procced", 23)]
-        BardStraightShotUpgradeFeature = 1L << 42,
+        BardStraightShotUpgradeFeature = 42,
 
         [CustomComboInfo("Quick Nock into Shadowbite", "Replaces Quick Nock/Ladonsbite with Shadowbite when procced", 23)]
-        BardAoEUpgradeFeature = 1L << 59,
+        BardAoEUpgradeFeature = 59,
 
         // MONK
         // you get nothing, you lose, have a nice day etc
 
         // RED MAGE
         [CustomComboInfo("Red Mage AoE Combo", "Replaces Veraero/thunder 2 with Impact when Dualcast or Swiftcast are active", 35)]
-        RedMageAoECombo = 1L << 48,
+        RedMageAoECombo = 48,
 
         [CustomComboInfo("Redoublement combo", "Replaces Redoublement with its combo chain, following enchantment rules", 35)]
-        RedMageMeleeCombo = 1L << 49,
+        RedMageMeleeCombo = 49,
 
         [CustomComboInfo("Verproc into Jolt", "Replaces Verstone/Verfire with Jolt/Scorch when no proc is available.", 35)]
-        RedMageVerprocCombo = 1L << 53,
+        RedMageVerprocCombo = 53,
 
         // REAPER
         [CustomComboInfo("Slice Combo", "Replace Slice with its combo chain.", 39)]
-        ReaperSliceCombo = 1L << 16,
+        ReaperSliceCombo = 16,
 
         [CustomComboInfo("Scythe Combo", "Replace Spinning Scythe with its combo chain.", 39)]
-        ReaperScytheCombo = 1L << 57,
+        ReaperScytheCombo = 57,
 
         [CustomComboInfo("Double Regress", "Regress always replaces both Hell's Egress and Hell's Ingress.", 39)]
-        ReaperRegressFeature = 1L << 58,
+        ReaperRegressFeature = 58,
 
         [CustomComboInfo("Enshroud Combo", "Replace Enshroud with Communio while you are Enshrouded.", 39)]
-        ReaperEnshroudCombo = 1L << 26,
+        ReaperEnshroudCombo = 26,
 
         [CustomComboInfo("Arcane Circle Combo", "Replace Arcane Circle with Plentiful Harvest while you have Immortal Sacrifice.", 39)]
-        ReaperArcaneFeature = 1L << 30,
+        ReaperArcaneFeature = 30,
     }
 
     public class CustomComboInfoAttribute : Attribute

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -6,187 +6,187 @@ namespace XIVComboPlugin
     {
         // DRAGOON
         [CustomComboInfo("Jump + Mirage Dive", "Replace (High) Jump with Mirage Dive when Dive Ready", 22)]
-        DragoonJumpFeature = 44,
+        DragoonJumpFeature,
 
         [CustomComboInfo("Coerthan Torment Combo", "Replace Coerthan Torment with its combo chain", 22)]
-        DragoonCoerthanTormentCombo = 0,
+        DragoonCoerthanTormentCombo,
 
         [CustomComboInfo("Chaos Thrust Combo", "Replace Chaos Thrust with its combo chain", 22)]
-        DragoonChaosThrustCombo = 1,
+        DragoonChaosThrustCombo,
 
         [CustomComboInfo("Full Thrust Combo", "Replace Full Thrust with its combo chain", 22)]
-        DragoonFullThrustCombo = 2,
+        DragoonFullThrustCombo,
 
         // DARK KNIGHT
         [CustomComboInfo("Souleater Combo", "Replace Souleater with its combo chain", 32)]
-        DarkSouleaterCombo = 3,
+        DarkSouleaterCombo,
 
         [CustomComboInfo("Stalwart Soul Combo", "Replace Stalwart Soul with its combo chain", 32)]
-        DarkStalwartSoulCombo = 4,
+        DarkStalwartSoulCombo,
 
         // PALADIN
         [CustomComboInfo("Royal Authority Combo", "Replace Royal Authority/Rage of Halone with its combo chain", 19)]
-        PaladinRoyalAuthorityCombo = 6,
+        PaladinRoyalAuthorityCombo,
 
         [CustomComboInfo("Prominence Combo", "Replace Prominence with its combo chain", 19)]
-        PaladinProminenceCombo = 7,
+        PaladinProminenceCombo,
 
         [CustomComboInfo("Requiescat Confiteor", "Replace Requiescat with Confiteor while under the effect of Requiescat", 19)]
-        PaladinRequiescatCombo = 55,
+        PaladinRequiescatCombo,
 
         // WARRIOR
         [CustomComboInfo("Storms Path Combo", "Replace Storms Path with its combo chain", 21)]
-        WarriorStormsPathCombo = 8,
+        WarriorStormsPathCombo,
 
         [CustomComboInfo("Storms Eye Combo", "Replace Storms Eye with its combo chain", 21)]
-        WarriorStormsEyeCombo = 9,
+        WarriorStormsEyeCombo,
 
         [CustomComboInfo("Mythril Tempest Combo", "Replace Mythril Tempest with its combo chain", 21)]
-        WarriorMythrilTempestCombo = 10,
+        WarriorMythrilTempestCombo,
 
         [CustomComboInfo("IR to Primal Rend", "Replace Inner Release with Primal Rend when Primal Rend Ready", 21)]
-        WarriorIRCombo = 63,
+        WarriorIRCombo,
 
         // SAMURAI
         [CustomComboInfo("Yukikaze Combo", "Replace Yukikaze with its combo chain", 34)]
-        SamuraiYukikazeCombo = 11,
+        SamuraiYukikazeCombo,
 
         [CustomComboInfo("Gekko Combo", "Replace Gekko with its combo chain", 34)]
-        SamuraiGekkoCombo = 12,
+        SamuraiGekkoCombo,
 
         [CustomComboInfo("Kasha Combo", "Replace Kasha with its combo chain", 34)]
-        SamuraiKashaCombo = 13,
+        SamuraiKashaCombo,
 
         [CustomComboInfo("Mangetsu Combo", "Replace Mangetsu with its combo chain", 34)]
-        SamuraiMangetsuCombo = 14,
+        SamuraiMangetsuCombo,
 
         [CustomComboInfo("Oka Combo", "Replace Oka with its combo chain", 34)]
-        SamuraiOkaCombo = 15,
+        SamuraiOkaCombo,
 
         [CustomComboInfo("Iaijutsu into Tsubame", "Replace Iaijutsu with Tsubame after using an Iaijutsu", 34)]
-        SamuraiTsubameCombo = 56,
+        SamuraiTsubameCombo,
 
         [CustomComboInfo("Ogi Namikiri Combo", "Replace Ikishoten with Ogi Namiki and Kaeshi Namikiri when appropriate", 34)]
-        SamuraiOgiCombo = 62,
+        SamuraiOgiCombo,
 
 
         // NINJA
         [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain", 30)]
-        NinjaArmorCrushCombo = 17,
+        NinjaArmorCrushCombo,
 
         [CustomComboInfo("Aeolian Edge Combo", "Replace Aeolian Edge with its combo chain", 30)]
-        NinjaAeolianEdgeCombo = 18,
+        NinjaAeolianEdgeCombo,
 
         [CustomComboInfo("Hakke Mujinsatsu Combo", "Replace Hakke Mujinsatsu with its combo chain", 30)]
-        NinjaHakkeMujinsatsuCombo = 19,
+        NinjaHakkeMujinsatsuCombo,
 
         // GUNBREAKER
         [CustomComboInfo("Solid Barrel Combo", "Replace Solid Barrel with its combo chain", 37)]
-        GunbreakerSolidBarrelCombo = 20,
+        GunbreakerSolidBarrelCombo,
 
         [CustomComboInfo("Wicked Talon Combo", "Replace Wicked Talon with its combo chain", 37)]
-        GunbreakerGnashingFangCombo = 21,
+        GunbreakerGnashingFangCombo,
 
         [CustomComboInfo("Wicked Talon Continuation", "In addition to the Wicked Talon combo chain, put Continuation moves on Wicked Talon when appropriate", 37)]
-        GunbreakerGnashingFangCont = 52,
+        GunbreakerGnashingFangCont,
 
         [CustomComboInfo("Burst Strike Continuation", "Put Continuation moves on Burst Strike when appropriate", 37)]
-        GunbreakerBurstStrikeCont = 45,
+        GunbreakerBurstStrikeCont,
 
         [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain", 37)]
-        GunbreakerDemonSlaughterCombo = 22,
+        GunbreakerDemonSlaughterCombo,
 
         // MACHINIST
         [CustomComboInfo("(Heated) Shot Combo", "Replace either form of Clean Shot with its combo chain", 31)]
-        MachinistMainCombo = 23,
+        MachinistMainCombo,
 
         [CustomComboInfo("Spread Shot Heat", "Replace Spread Shot or Scattergun with Auto Crossbow when overheated", 31)]
-        MachinistSpreadShotFeature = 24,
+        MachinistSpreadShotFeature,
 
         [CustomComboInfo("Heat Blast when overheated", "Replace Hypercharge with Heat Blast when overheated", 31)]
-        MachinistOverheatFeature = 47,
+        MachinistOverheatFeature,
 
         // BLACK MAGE
         [CustomComboInfo("Enochian Stance Switcher", "Change Fire 4 and Blizzard 4 to the appropriate element depending on stance, as well as Flare and Freeze", 25)]
-        BlackEnochianFeature = 25,
+        BlackEnochianFeature,
 
         [CustomComboInfo("(Between the) Ley Lines", "Change Ley Lines into BTL when Ley Lines is active", 25)]
-        BlackLeyLines = 28,
+        BlackLeyLines,
 
         // ASTROLOGIAN
         [CustomComboInfo("Draw on Play", "Play turns into Draw when no card is drawn, as well as the usual Play behavior", 33)]
-        AstrologianCardsOnDrawFeature = 27,
+        AstrologianCardsOnDrawFeature,
 
         // SUMMONER
 
         [CustomComboInfo("ED Fester", "Change Fester into Energy Drain when out of Aetherflow stacks", 27)]
-        SummonerEDFesterCombo = 39,
+        SummonerEDFesterCombo,
 
         [CustomComboInfo("ES Painflare", "Change Painflare into Energy Syphon when out of Aetherflow stacks", 27)]
-        SummonerESPainflareCombo = 40,
+        SummonerESPainflareCombo,
         
         // SCHOLAR
         [CustomComboInfo("Seraph Fey Blessing/Consolation", "Change Fey Blessing into Consolation when Seraph is out", 28)]
-        ScholarSeraphConsolationFeature = 29,
+        ScholarSeraphConsolationFeature,
 
         [CustomComboInfo("ED Aetherflow", "Change Energy Drain into Aetherflow when you have no more Aetherflow stacks", 28)]
-        ScholarEnergyDrainFeature = 37,
+        ScholarEnergyDrainFeature,
 
         // DANCER
         [CustomComboInfo("AoE GCD procs", "DNC AoE procs turn into their normal abilities when not procced", 38)]
-        DancerAoeGcdFeature = 32,
+        DancerAoeGcdFeature,
 
         [CustomComboInfo("Fan Dance Combos", "Change Fan Dance and Fan Dance 2 into Fan Dance 3 while flourishing", 38)]
-        DancerFanDanceCombo = 33,
+        DancerFanDanceCombo,
 
         [CustomComboInfo("Fan Dance IV", "Change Flourish into Fan Dance IV while flourishing", 38)]
-        DancerFanDance4Combo = 60,
+        DancerFanDance4Combo,
 
         [CustomComboInfo("Devilment into Starfall", "Change Devilment into Starfall Dance while under the effect of Flourishing Starfall", 38)]
-        DancerDevilmentCombo = 61,
+        DancerDevilmentCombo,
 
         // WHITE MAGE
         [CustomComboInfo("Solace into Misery", "Replaces Afflatus Solace with Afflatus Misery when Misery is ready to be used", 24)]
-        WhiteMageSolaceMiseryFeature = 35,
+        WhiteMageSolaceMiseryFeature,
 
         [CustomComboInfo("Rapture into Misery", "Replaces Afflatus Rapture with Afflatus Misery when Misery is ready to be used", 24)]
-        WhiteMageRaptureMiseryFeature = 36,
+        WhiteMageRaptureMiseryFeature,
 
         // BARD
         [CustomComboInfo("Heavy Shot into Straight Shot", "Replaces Heavy Shot/Burst Shot with Straight Shot/Refulgent Arrow when procced", 23)]
-        BardStraightShotUpgradeFeature = 42,
+        BardStraightShotUpgradeFeature,
 
         [CustomComboInfo("Quick Nock into Shadowbite", "Replaces Quick Nock/Ladonsbite with Shadowbite when procced", 23)]
-        BardAoEUpgradeFeature = 59,
+        BardAoEUpgradeFeature,
 
         // MONK
         // you get nothing, you lose, have a nice day etc
 
         // RED MAGE
         [CustomComboInfo("Red Mage AoE Combo", "Replaces Veraero/thunder 2 with Impact when Dualcast or Swiftcast are active", 35)]
-        RedMageAoECombo = 48,
+        RedMageAoECombo,
 
         [CustomComboInfo("Redoublement combo", "Replaces Redoublement with its combo chain, following enchantment rules", 35)]
-        RedMageMeleeCombo = 49,
+        RedMageMeleeCombo,
 
         [CustomComboInfo("Verproc into Jolt", "Replaces Verstone/Verfire with Jolt/Scorch when no proc is available.", 35)]
-        RedMageVerprocCombo = 53,
+        RedMageVerprocCombo,
 
         // REAPER
         [CustomComboInfo("Slice Combo", "Replace Slice with its combo chain.", 39)]
-        ReaperSliceCombo = 16,
+        ReaperSliceCombo,
 
         [CustomComboInfo("Scythe Combo", "Replace Spinning Scythe with its combo chain.", 39)]
-        ReaperScytheCombo = 57,
+        ReaperScytheCombo,
 
         [CustomComboInfo("Double Regress", "Regress always replaces both Hell's Egress and Hell's Ingress.", 39)]
-        ReaperRegressFeature = 58,
+        ReaperRegressFeature,
 
         [CustomComboInfo("Enshroud Combo", "Replace Enshroud with Communio while you are Enshrouded.", 39)]
-        ReaperEnshroudCombo = 26,
+        ReaperEnshroudCombo,
 
         [CustomComboInfo("Arcane Circle Combo", "Replace Arcane Circle with Plentiful Harvest while you have Immortal Sacrifice.", 39)]
-        ReaperArcaneFeature = 30,
+        ReaperArcaneFeature,
     }
 
     public class CustomComboInfoAttribute : Attribute

--- a/XIVComboPlugin/Configuration/LegacyCustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/LegacyCustomComboPreset.cs
@@ -1,0 +1,102 @@
+﻿using System;
+
+namespace XIVComboPlugin
+{
+    [Flags]
+    public enum LegacyCustomComboPreset : long
+    {
+        None = 0,
+
+        // DRAGOON
+        DragoonJumpFeature = 1L << 44,
+        DragoonCoerthanTormentCombo = 1L << 0,
+        DragoonChaosThrustCombo = 1L << 1,
+        DragoonFullThrustCombo = 1L << 2,
+
+        // DARK KNIGHT
+        DarkSouleaterCombo = 1L << 3,
+        DarkStalwartSoulCombo = 1L << 4,
+
+        // PALADIN
+        PaladinRoyalAuthorityCombo = 1L << 6,
+        PaladinProminenceCombo = 1L << 7,
+        PaladinRequiescatCombo = 1L << 55,
+
+        // WARRIOR
+        WarriorStormsPathCombo = 1L << 8,
+        WarriorStormsEyeCombo = 1L << 9,
+
+        WarriorMythrilTempestCombo = 1L << 10,
+        WarriorIRCombo = 1L << 63,
+
+        // SAMURAI
+        SamuraiYukikazeCombo = 1L << 11,
+        SamuraiGekkoCombo = 1L << 12,
+        SamuraiKashaCombo = 1L << 13,
+        SamuraiMangetsuCombo = 1L << 14,
+        SamuraiOkaCombo = 1L << 15,
+        SamuraiTsubameCombo = 1L << 56,
+        SamuraiOgiCombo = 1L << 62,
+
+        // NINJA
+        NinjaArmorCrushCombo = 1L << 17,
+        NinjaAeolianEdgeCombo = 1L << 18,
+        NinjaHakkeMujinsatsuCombo = 1L << 19,
+
+        // GUNBREAKER
+        GunbreakerSolidBarrelCombo = 1L << 20,
+        GunbreakerGnashingFangCombo = 1L << 21,
+        GunbreakerGnashingFangCont = 1L << 52,
+        GunbreakerBurstStrikeCont = 1L << 45,
+        GunbreakerDemonSlaughterCombo = 1L << 22,
+
+        // MACHINIST
+        MachinistMainCombo = 1L << 23,
+        MachinistSpreadShotFeature = 1L << 24,
+        MachinistOverheatFeature = 1L << 47,
+
+        // BLACK MAGE
+        BlackEnochianFeature = 1L << 25,
+        BlackLeyLines = 1L << 28,
+
+        // ASTROLOGIAN
+        AstrologianCardsOnDrawFeature = 1L << 27,
+
+        // SUMMONER
+        SummonerEDFesterCombo = 1L << 39,
+        SummonerESPainflareCombo = 1L << 40,
+
+        // SCHOLAR
+        ScholarSeraphConsolationFeature = 1L << 29,
+        ScholarEnergyDrainFeature = 1L << 37,
+
+        // DANCER
+        DancerAoeGcdFeature = 1L << 32,
+        DancerFanDanceCombo = 1L << 33,
+        DancerFanDance4Combo = 1L << 60,
+        DancerDevilmentCombo = 1L << 61,
+
+        // WHITE MAGE
+        WhiteMageSolaceMiseryFeature = 1L << 35,
+        WhiteMageRaptureMiseryFeature = 1L << 36,
+
+        // BARD
+        BardStraightShotUpgradeFeature = 1L << 42,
+        BardAoEUpgradeFeature = 1L << 59,
+
+        // MONK
+        // you get nothing, you lose, have a nice day etc
+
+        // RED MAGE
+        RedMageAoECombo = 1L << 48,
+        RedMageMeleeCombo = 1L << 49,
+        RedMageVerprocCombo = 1L << 53,
+
+        // REAPER
+        ReaperSliceCombo = 1L << 16,
+        ReaperScytheCombo = 1L << 57,
+        ReaperRegressFeature = 1L << 58,
+        ReaperEnshroudCombo = 1L << 26,
+        ReaperArcaneFeature = 1L << 30,
+    }
+}

--- a/XIVComboPlugin/Configuration/XIVComboConfiguration.cs
+++ b/XIVComboPlugin/Configuration/XIVComboConfiguration.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Dalamud.Configuration;
 using Dalamud.Plugin;
+using Dalamud.Utility;
 using Newtonsoft.Json;
 
 namespace XIVComboPlugin
@@ -11,10 +13,85 @@ namespace XIVComboPlugin
     public class XIVComboConfiguration : IPluginConfiguration
     {
 
-        public CustomComboPreset ComboPresets { get; set; }
+        public LegacyCustomComboPreset ComboPresets { get; set; }
+
+        public Dictionary<string, bool> CombosEnabled { get; set; }
+
         public int Version { get; set; }
 
         public List<bool> HiddenActions;
 
+        private Dictionary<CustomComboPreset, bool> CachedCombosEnabled { get; set; }
+
+        public void Initialize()
+        {
+            if (Version < 4) Version = 4;
+
+            if (CombosEnabled == null)
+                MigrateCombosEnabledFromLegacy();
+
+            // TODO delete legacy ComboPresets from config file
+        }
+
+        public void SetComboEnabled(CustomComboPreset combo, bool enabled = true)
+        {
+            if (IsComboEnabled(combo) == enabled)
+                return;
+
+            CombosEnabled[combo.ToString()] = enabled;
+            CachedCombosEnabled = null;
+        }
+
+        public bool IsComboEnabled(CustomComboPreset combo)
+        {
+            if (CachedCombosEnabled == null)
+                CachedCombosEnabled = GetComboEnabledStates();
+            return CachedCombosEnabled[combo];
+        }
+
+        public Dictionary<CustomComboPreset, bool> GetComboEnabledStates()
+        {
+            var states = new Dictionary<CustomComboPreset, bool>();
+            var combos = Enum.GetValues(typeof(CustomComboPreset)).Cast<CustomComboPreset>();
+            foreach (var combo in combos)
+            {
+                if (CombosEnabled.ContainsKey(combo.ToString()))
+                    states[combo] = CombosEnabled[combo.ToString()];
+                else
+                    states[combo] = false;
+            }
+            return states;
+        }
+
+        private void MigrateCombosEnabledFromLegacy()
+        {
+            CombosEnabled = new Dictionary<string, bool>();
+
+            var combos = Enum.GetValues(typeof(CustomComboPreset)).Cast<CustomComboPreset>()
+                .Where(x => x.GetAttribute<CustomComboInfoAttribute>() != null);
+
+            foreach (var combo in combos)
+            {
+                var legacyCombo = FindLegacyComboByName(combo.ToString());
+                if (legacyCombo.HasValue)
+                {
+                    var legacyVal = ComboPresets.HasFlag(legacyCombo);
+                    SetComboEnabled(combo, legacyVal);
+                }
+                else
+                    SetComboEnabled(combo, false);
+            }
+        }
+
+        private LegacyCustomComboPreset? FindLegacyComboByName(string name)
+        {
+            var list = Enum.GetValues(typeof(LegacyCustomComboPreset)).Cast<LegacyCustomComboPreset>()
+                .Where(legacyCombo =>  name.Equals(legacyCombo.ToString()));
+
+            if (list.Any())
+                return list.First();
+            else
+                return null;
+        }
     }
 }

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -113,7 +113,7 @@ namespace XIVComboPlugin
             // DRAGOON
 
             // Change Jump/High Jump into Mirage Dive when Dive Ready
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonJumpFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.DragoonJumpFeature))
                 if (actionID == DRG.Jump || actionID == DRG.HighJump)
                 {
                     if (SearchBuffArray(1243))
@@ -122,7 +122,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Coerthan Torment with Coerthan Torment combo chain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonCoerthanTormentCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.DragoonCoerthanTormentCombo))
                 if (actionID == DRG.CTorment)
                 {
                     if (comboTime > 0)
@@ -137,7 +137,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Chaos Thrust with the Chaos Thrust combo chain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonChaosThrustCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.DragoonChaosThrustCombo))
                 if (actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring)
                 {
                     if (comboTime > 0)
@@ -163,7 +163,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Full Thrust with the Full Thrust combo chain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonFullThrustCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.DragoonFullThrustCombo))
                 if (actionID == DRG.FullThrust || actionID == DRG.HeavensThrust)
                 {
                     if (comboTime > 0)
@@ -191,7 +191,7 @@ namespace XIVComboPlugin
             // DARK KNIGHT
 
             // Replace Souleater with Souleater combo chain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DarkSouleaterCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.DarkSouleaterCombo))
                 if (actionID == DRK.Souleater)
                 {
                     if (comboTime > 0)
@@ -206,7 +206,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Stalwart Soul with Stalwart Soul combo chain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DarkStalwartSoulCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.DarkStalwartSoulCombo))
                 if (actionID == DRK.StalwartSoul)
                 {
                     if (comboTime > 0)
@@ -219,7 +219,7 @@ namespace XIVComboPlugin
             // PALADIN
 
             // Replace Royal Authority with Royal Authority combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinRoyalAuthorityCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.PaladinRoyalAuthorityCombo))
                 if (actionID == PLD.RoyalAuthority || actionID == PLD.RageOfHalone)
                 {
                     if (comboTime > 0)
@@ -239,7 +239,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Prominence with Prominence combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinProminenceCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.PaladinProminenceCombo))
                 if (actionID == PLD.Prominence)
                 {
                     if (comboTime > 0)
@@ -250,7 +250,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Requiescat with Confiteor when under the effect of Requiescat
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.PaladinRequiescatCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.PaladinRequiescatCombo))
                 if (actionID == PLD.Requiescat)
                 {
                     if (SearchBuffArray(PLD.BuffRequiescat) && level >= 80)
@@ -261,7 +261,7 @@ namespace XIVComboPlugin
             // WARRIOR
 
             // Replace Storm's Path with Storm's Path combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WarriorStormsPathCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.WarriorStormsPathCombo))
                 if (actionID == WAR.StormsPath)
                 {
                     if (comboTime > 0)
@@ -276,7 +276,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Storm's Eye with Storm's Eye combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WarriorStormsEyeCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.WarriorStormsEyeCombo))
                 if (actionID == WAR.StormsEye)
                 {
                     if (comboTime > 0)
@@ -291,7 +291,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Mythril Tempest with Mythril Tempest combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WarriorMythrilTempestCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.WarriorMythrilTempestCombo))
                 if (actionID == WAR.MythrilTempest)
                 {
                     if (comboTime > 0)
@@ -300,7 +300,7 @@ namespace XIVComboPlugin
                     return WAR.Overpower;
                 }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WarriorIRCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.WarriorIRCombo))
                 if (actionID == WAR.InnerRelease || actionID == WAR.Berserk)
                 {
                     if (SearchBuffArray(WAR.BuffPrimalRendReady))
@@ -310,7 +310,7 @@ namespace XIVComboPlugin
 
             // SAMURAI
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiTsubameCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.SamuraiTsubameCombo))
                 if (actionID == SAM.Iaijutsu)
                 {
                     var x = iconHook.Original(self, SAM.Tsubame);
@@ -319,7 +319,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Yukikaze with Yukikaze combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiYukikazeCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.SamuraiYukikazeCombo))
                 if (actionID == SAM.Yukikaze)
                 {
                     if (SearchBuffArray(SAM.BuffMeikyoShisui))
@@ -331,7 +331,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Gekko with Gekko combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiGekkoCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.SamuraiGekkoCombo))
                 if (actionID == SAM.Gekko)
                 {
                     if (SearchBuffArray(SAM.BuffMeikyoShisui))
@@ -348,7 +348,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Kasha with Kasha combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiKashaCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.SamuraiKashaCombo))
                 if (actionID == SAM.Kasha)
                 {
                     if (SearchBuffArray(SAM.BuffMeikyoShisui))
@@ -365,7 +365,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Mangetsu with Mangetsu combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiMangetsuCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.SamuraiMangetsuCombo))
                 if (actionID == SAM.Mangetsu)
                 {
                     if (SearchBuffArray(SAM.BuffMeikyoShisui))
@@ -379,7 +379,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Oka with Oka combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiOkaCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.SamuraiOkaCombo))
                 if (actionID == SAM.Oka)
                 {
                     if (SearchBuffArray(SAM.BuffMeikyoShisui))
@@ -392,7 +392,7 @@ namespace XIVComboPlugin
                     return SAM.Fuga;
                 }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SamuraiOgiCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.SamuraiOgiCombo))
                 if (actionID == SAM.Ikishoten)
                 {
                     if (SearchBuffArray(SAM.BuffOgiNamikiriReady))
@@ -406,7 +406,7 @@ namespace XIVComboPlugin
             // NINJA
 
             // Replace Armor Crush with Armor Crush combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaArmorCrushCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.NinjaArmorCrushCombo))
                 if (actionID == NIN.ArmorCrush)
                 {
                     if (comboTime > 0)
@@ -421,7 +421,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Aeolian Edge with Aeolian Edge combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaAeolianEdgeCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.NinjaAeolianEdgeCombo))
                 if (actionID == NIN.AeolianEdge)
                 {
                     if (comboTime > 0)
@@ -436,7 +436,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Hakke Mujinsatsu with Hakke Mujinsatsu combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaHakkeMujinsatsuCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.NinjaHakkeMujinsatsuCombo))
                 if (actionID == NIN.HakkeM)
                 {
                     if (comboTime > 0)
@@ -450,7 +450,7 @@ namespace XIVComboPlugin
             // GUNBREAKER
 
             // Replace Solid Barrel with Solid Barrel combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerSolidBarrelCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.GunbreakerSolidBarrelCombo))
                 if (actionID == GNB.SolidBarrel)
                 {
                     if (comboTime > 0)
@@ -464,7 +464,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Wicked Talon with Gnashing Fang combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerGnashingFangCont))
+            if (Configuration.IsComboEnabled(CustomComboPreset.GunbreakerGnashingFangCont))
                 if (actionID == GNB.GnashingFang)
                 {
                     if (level >= GNB.LevelContinuation)
@@ -480,7 +480,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Burst Strike with Continuation
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerBurstStrikeCont))
+            if (Configuration.IsComboEnabled(CustomComboPreset.GunbreakerBurstStrikeCont))
                 if (actionID == GNB.BurstStrike)
                 {
                     if (level >= GNB.LevelEnhancedContinuation)
@@ -492,7 +492,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Demon Slaughter with Demon Slaughter combo
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerDemonSlaughterCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.GunbreakerDemonSlaughterCombo))
                 if (actionID == GNB.DemonSlaughter)
                 {
                     if (comboTime > 0)
@@ -506,7 +506,7 @@ namespace XIVComboPlugin
             // Replace Clean Shot with Heated Clean Shot combo
             // Or with Heat Blast when overheated.
             // For some reason the shots use their unheated IDs as combo moves
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistMainCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.MachinistMainCombo))
                 if (actionID == MCH.CleanShot || actionID == MCH.HeatedCleanShot)
                 {
                     if (comboTime > 0)
@@ -535,7 +535,7 @@ namespace XIVComboPlugin
 
 
             // Replace Hypercharge with Heat Blast when overheated
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistOverheatFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.MachinistOverheatFeature))
                 if (actionID == MCH.Hypercharge)
                 {
                     var gauge = XIVComboPlugin.JobGauges.Get<MCHGauge>();
@@ -545,7 +545,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Spread Shot with Auto Crossbow when overheated.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistSpreadShotFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.MachinistSpreadShotFeature))
                 if (actionID == MCH.SpreadShot || actionID == MCH.Scattergun)
                 {
                     if (XIVComboPlugin.JobGauges.Get<MCHGauge>().IsOverheated && level >= 52)
@@ -558,7 +558,7 @@ namespace XIVComboPlugin
             // BLACK MAGE
 
             // B4 and F4 change to each other depending on stance, as do Flare and Freeze.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BlackEnochianFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.BlackEnochianFeature))
             {
                 if (actionID == BLM.Fire4 || actionID == BLM.Blizzard4)
                 {
@@ -579,7 +579,7 @@ namespace XIVComboPlugin
             }
 
             // Ley Lines and BTL
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BlackLeyLines))
+            if (Configuration.IsComboEnabled(CustomComboPreset.BlackLeyLines))
                 if (actionID == BLM.LeyLines)
                 {
                     if (SearchBuffArray(BLM.BuffLeyLines) && level >= 62)
@@ -590,7 +590,7 @@ namespace XIVComboPlugin
             // ASTROLOGIAN
 
             // Make cards on the same button as play
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.AstrologianCardsOnDrawFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.AstrologianCardsOnDrawFeature))
                 if (actionID == AST.Play)
                 {
                     var gauge = XIVComboPlugin.JobGauges.Get<ASTGauge>();
@@ -615,7 +615,7 @@ namespace XIVComboPlugin
 
             // SUMMONER
             // Change Fester into Energy Drain
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SummonerEDFesterCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.SummonerEDFesterCombo))
                 if (actionID == SMN.Fester)
                 {
                     if (!XIVComboPlugin.JobGauges.Get<SMNGauge>().HasAetherflowStacks)
@@ -624,7 +624,7 @@ namespace XIVComboPlugin
                 }
 
             //Change Painflare into Energy Syphon
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SummonerESPainflareCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.SummonerESPainflareCombo))
                 if (actionID == SMN.Painflare)
                 {
                     if (!XIVComboPlugin.JobGauges.Get<SMNGauge>().HasAetherflowStacks)
@@ -635,7 +635,7 @@ namespace XIVComboPlugin
             // SCHOLAR
 
             // Change Fey Blessing into Consolation when Seraph is out.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ScholarSeraphConsolationFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.ScholarSeraphConsolationFeature))
                 if (actionID == SCH.FeyBless)
                 {
                     if (XIVComboPlugin.JobGauges.Get<SCHGauge>().SeraphTimer > 0) return SCH.Consolation;
@@ -643,7 +643,7 @@ namespace XIVComboPlugin
                 }
 
             // Change Energy Drain into Aetherflow when you have no more Aetherflow stacks.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ScholarEnergyDrainFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.ScholarEnergyDrainFeature))
                 if (actionID == SCH.EnergyDrain)
                 {
                     if (XIVComboPlugin.JobGauges.Get<SCHGauge>().Aetherflow == 0) return SCH.Aetherflow;
@@ -655,7 +655,7 @@ namespace XIVComboPlugin
             // AoE GCDs are split into two buttons, because priority matters
             // differently in different single-target moments. Thanks yoship.
             // Replaces each GCD with its procced version.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DancerAoeGcdFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.DancerAoeGcdFeature))
             {
                 if (actionID == DNC.Bloodshower)
                 {
@@ -673,7 +673,7 @@ namespace XIVComboPlugin
             }
 
             // Fan Dance changes into Fan Dance 3 while flourishing.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DancerFanDanceCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.DancerFanDanceCombo))
             {
                 if (actionID == DNC.FanDance1)
                 {
@@ -691,7 +691,7 @@ namespace XIVComboPlugin
                 }
             }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DancerFanDance4Combo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.DancerFanDance4Combo))
             {
                 if (actionID == DNC.Flourish)
                 {
@@ -701,7 +701,7 @@ namespace XIVComboPlugin
                 }
             }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DancerDevilmentCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.DancerDevilmentCombo))
             {
                 if (actionID == DNC.Devilment)
                 {
@@ -714,7 +714,7 @@ namespace XIVComboPlugin
             // WHM
 
             // Replace Solace with Misery when full blood lily
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WhiteMageSolaceMiseryFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.WhiteMageSolaceMiseryFeature))
                 if (actionID == WHM.Solace)
                 {
                     if (XIVComboPlugin.JobGauges.Get<WHMGauge>().BloodLily == 3)
@@ -723,7 +723,7 @@ namespace XIVComboPlugin
                 }
 
             // Replace Solace with Misery when full blood lily
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.WhiteMageRaptureMiseryFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.WhiteMageRaptureMiseryFeature))
                 if (actionID == WHM.Rapture)
                 {
                     if (XIVComboPlugin.JobGauges.Get<WHMGauge>().BloodLily == 3)
@@ -734,7 +734,7 @@ namespace XIVComboPlugin
             // BARD
 
             // Replace HS/BS with SS/RA when procced.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BardStraightShotUpgradeFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.BardStraightShotUpgradeFeature))
                 if (actionID == BRD.HeavyShot || actionID == BRD.BurstShot)
                 {
                     if (SearchBuffArray(BRD.BuffStraightShotReady))
@@ -747,7 +747,7 @@ namespace XIVComboPlugin
                     return BRD.HeavyShot;
                 }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BardAoEUpgradeFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.BardAoEUpgradeFeature))
                 if (actionID == BRD.QuickNock || actionID == BRD.Ladonsbite)
                 {
                     if (SearchBuffArray(BRD.BuffShadowbiteReady))
@@ -764,7 +764,7 @@ namespace XIVComboPlugin
             // RED MAGE
 
             // Replace Veraero/thunder 2 with Impact when Dualcast is active
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.RedMageAoECombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.RedMageAoECombo))
             {
                 if (actionID == RDM.Veraero2)
                 {
@@ -790,7 +790,7 @@ namespace XIVComboPlugin
             }
 
             // Replace Redoublement with Redoublement combo, Enchanted if possible.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.RedMageMeleeCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.RedMageMeleeCombo))
                 if (actionID == RDM.Redoublement)
                 {
                     var gauge = XIVComboPlugin.JobGauges.Get<RDMGauge>();
@@ -813,7 +813,7 @@ namespace XIVComboPlugin
                     return RDM.Riposte;
                 }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.RedMageVerprocCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.RedMageVerprocCombo))
             {
                 if (actionID == RDM.Verstone)
                 {
@@ -837,7 +837,7 @@ namespace XIVComboPlugin
 
             // REAPER 
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperSliceCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.ReaperSliceCombo))
             {
                 if (actionID == RPR.Slice)
                 {
@@ -853,7 +853,7 @@ namespace XIVComboPlugin
                 }
             }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperScytheCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.ReaperScytheCombo))
             {
                 if (actionID == RPR.SpinningScythe)
                 {
@@ -867,7 +867,7 @@ namespace XIVComboPlugin
                 }
             }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperRegressFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.ReaperRegressFeature))
             {
                 if (actionID == RPR.Egress || actionID == RPR.Ingress)
                 {
@@ -876,7 +876,7 @@ namespace XIVComboPlugin
                 }
             }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperEnshroudCombo))
+            if (Configuration.IsComboEnabled(CustomComboPreset.ReaperEnshroudCombo))
             {
                 if (actionID == RPR.Enshroud)
                 {
@@ -885,7 +885,7 @@ namespace XIVComboPlugin
                 }
             }
 
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ReaperArcaneFeature))
+            if (Configuration.IsComboEnabled(CustomComboPreset.ReaperArcaneFeature))
             {
                 if (actionID == RPR.ArcaneCircle)
                 {


### PR DESCRIPTION
The CustomComboPreset enum cannot store more than 63 flags because it's serialized as a 64-bit bitmask. This PR changes the config file such that each combo setting is stored as a separate key in a Dict instead. Old configs are migrated to the new format. Plugin behavior is functionally unchanged.