### PR TITLE
Updated GNB, RDM, MCH, disabled AST for now

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -97,6 +97,9 @@ namespace XIVComboPlugin
         [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain", 37)]
         GunbreakerDemonSlaughterCombo = 1L << 22,
 
+        [CustomComboInfo("Fated Circle Continuation", "Put Continuation moves on Fated Circle when appropriate", 37)]
+        GunbreakerFatedCircleCont = 1L << 54,
+
         // MACHINIST
         [CustomComboInfo("(Heated) Shot Combo", "Replace either form of Clean Shot with its combo chain", 31)]
         MachinistMainCombo = 1L << 23,
@@ -115,8 +118,10 @@ namespace XIVComboPlugin
         BlackLeyLines = 1L << 28,
 
         // ASTROLOGIAN
+        /* Old Astro
         [CustomComboInfo("Draw on Play", "Play turns into Draw when no card is drawn, as well as the usual Play behavior", 33)]
         AstrologianCardsOnDrawFeature = 1L << 27,
+        */
 
         // SUMMONER
 

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -9,8 +9,8 @@ namespace XIVComboPlugin
         None = 0,
 
         // DRAGOON
-        [CustomComboInfo("Jump + Mirage Dive", "Replace (High) Jump with Mirage Dive when Dive Ready", 22)]
-        DragoonJumpFeature = 1L << 44,
+        //[CustomComboInfo("Jump + Mirage Dive", "Replace (High) Jump with Mirage Dive when Dive Ready", 22)]
+        //DragoonJumpFeature = 1L << 44,
 
         [CustomComboInfo("Coerthan Torment Combo", "Replace Coerthan Torment with its combo chain", 22)]
         DragoonCoerthanTormentCombo = 1L << 0,
@@ -114,8 +114,8 @@ namespace XIVComboPlugin
         [CustomComboInfo("Enochian Stance Switcher", "Change Fire 4 and Blizzard 4 to the appropriate element depending on stance, as well as Flare and Freeze", 25)]
         BlackEnochianFeature = 1L << 25,
 
-        [CustomComboInfo("(Between the) Ley Lines", "Change Ley Lines into BTL when Ley Lines is active", 25)]
-        BlackLeyLines = 1L << 28,
+        //[CustomComboInfo("(Between the) Ley Lines", "Change Ley Lines into BTL when Ley Lines is active", 25)]
+        //BlackLeyLines = 1L << 28,
 
         // ASTROLOGIAN
         /* Old Astro
@@ -132,8 +132,8 @@ namespace XIVComboPlugin
         SummonerESPainflareCombo = 1L << 40,
         
         // SCHOLAR
-        [CustomComboInfo("Seraph Fey Blessing/Consolation", "Change Fey Blessing into Consolation when Seraph is out", 28)]
-        ScholarSeraphConsolationFeature = 1L << 29,
+        //[CustomComboInfo("Seraph Fey Blessing/Consolation", "Change Fey Blessing into Consolation when Seraph is out", 28)]
+        //ScholarSeraphConsolationFeature = 1L << 29,
 
         [CustomComboInfo("ED Aetherflow", "Change Energy Drain into Aetherflow when you have no more Aetherflow stacks", 28)]
         ScholarEnergyDrainFeature = 1L << 37,

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -125,7 +125,7 @@ namespace XIVComboPlugin
 
         // SUMMONER
 
-        [CustomComboInfo("ED Fester", "Change Fester into Energy Drain when out of Aetherflow stacks", 27)]
+        [CustomComboInfo("ED Fester", "Change Fester and Necrotize into Energy Drain when out of Aetherflow stacks", 27)]
         SummonerEDFesterCombo = 1L << 39,
 
         [CustomComboInfo("ES Painflare", "Change Painflare into Energy Syphon when out of Aetherflow stacks", 27)]

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -676,11 +676,11 @@ namespace XIVComboPlugin
             // SUMMONER
             // Change Fester into Energy Drain
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.SummonerEDFesterCombo))
-                if (actionID == SMN.Fester)
+                if (actionID == SMN.Fester || actionID == SMN.Necrotize)
                 {
                     if (!JobGauges.Get<SMNGauge>().HasAetherflowStacks)
                         return SMN.EnergyDrain;
-                    return SMN.Fester;
+                    return actionID;
                 }
 
             //Change Painflare into Energy Syphon

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -258,6 +258,13 @@ namespace XIVComboPlugin
                 {
                     if (SearchBuffArray(PLD.BuffRequiescat) && level >= 80)
                         return iconHook.Original(self, PLD.Confiteor);
+
+                    if (SearchBuffArray(PLD.BuffBladeOfHonor)) 
+                        return PLD.BladeOfHonor;
+
+                    if (level >= 96)
+                        return PLD.Imperator;
+
                     return PLD.Requiescat;
                 }
 
@@ -330,6 +337,9 @@ namespace XIVComboPlugin
                     if (comboTime > 0)
                         if (lastMove == SAM.Hakaze && level >= 50)
                             return SAM.Yukikaze;
+
+                    if (level >= 92)
+                        return SAM.Gyuofu;
                     return SAM.Hakaze;
                 }
 
@@ -347,6 +357,8 @@ namespace XIVComboPlugin
                             return SAM.Gekko;
                     }
 
+                    if (level >= 92)
+                        return SAM.Gyuofu;
                     return SAM.Hakaze;
                 }
 
@@ -364,6 +376,8 @@ namespace XIVComboPlugin
                             return SAM.Kasha;
                     }
 
+                    if (level >= 92) 
+                        return SAM.Gyuofu;
                     return SAM.Hakaze;
                 }
 
@@ -402,7 +416,9 @@ namespace XIVComboPlugin
                         return SAM.OgiNamikiri;
                     if (JobGauges.Get<SAMGauge>().Kaeshi == Kaeshi.NAMIKIRI)
                         return SAM.KaeshiNamikiri;
-                        
+
+                    if (SearchBuffArray(SAM.BuffZanshinReady)) return SAM.Zanshin;
+
                     return SAM.Ikishoten;
                 }
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -504,6 +504,18 @@ namespace XIVComboPlugin
                     return GNB.DemonSlice;
                 }
 
+            // Replace Fated Brand with Continuation
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerFatedCircleCont))
+                if (actionID == GNB.FatedCircle)
+                {
+                    if (level >= GNB.LevelEnhancedContinuation2)
+                    {
+                        if (SearchBuffArray(GNB.BuffReadyToRaze))
+                            return GNB.FatedBrand;
+                    }
+                    return GNB.FatedCircle;
+                }
+
             // MACHINIST
 
             // Replace Clean Shot with Heated Clean Shot combo
@@ -543,7 +555,10 @@ namespace XIVComboPlugin
                 {
                     var gauge = JobGauges.Get<MCHGauge>();
                     if (gauge.IsOverheated && level >= 35)
-                        return MCH.HeatBlast;
+                        if (level >= 68)
+                            return MCH.BlazingShot;
+                        else
+                            return MCH.HeatBlast;
                     return MCH.Hypercharge;
                 }
 
@@ -592,7 +607,7 @@ namespace XIVComboPlugin
 
             // ASTROLOGIAN
 
-            // Make cards on the same button as play
+            /* Old Astro
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.AstrologianCardsOnDrawFeature))
                 if (actionID == AST.Play)
                 {
@@ -615,6 +630,7 @@ namespace XIVComboPlugin
                             return AST.Draw;
                     }
                 }
+            */
 
             // SUMMONER
             // Change Fester into Energy Drain
@@ -799,19 +815,19 @@ namespace XIVComboPlugin
                     var gauge = JobGauges.Get<RDMGauge>();
                     if ((lastMove == RDM.Riposte || lastMove == RDM.ERiposte) && level >= 35)
                     {
-                        if (gauge.BlackMana >= 15 && gauge.WhiteMana >= 15)
+                        if (gauge.BlackMana >= 15 && gauge.WhiteMana >= 15 || SearchBuffArray(RDM.BuffMagickedSwordplay))
                             return RDM.EZwerchhau;
                         return RDM.Zwerchhau;
                     }
 
                     if (lastMove == RDM.Zwerchhau && level >= 50)
                     {
-                        if (gauge.BlackMana >= 15 && gauge.WhiteMana >= 15)
+                        if (gauge.BlackMana >= 15 && gauge.WhiteMana >= 15 || SearchBuffArray(RDM.BuffMagickedSwordplay))
                             return RDM.ERedoublement;
                         return RDM.Redoublement;
                     }
 
-                    if (gauge.BlackMana >= 20 && gauge.WhiteMana >= 20)
+                    if (gauge.BlackMana >= 20 && gauge.WhiteMana >= 20 || SearchBuffArray(RDM.BuffMagickedSwordplay))
                         return RDM.ERiposte;
                     return RDM.Riposte;
                 }
@@ -825,7 +841,8 @@ namespace XIVComboPlugin
 
                     if (SearchBuffArray(RDM.BuffVerstoneReady)) return RDM.Verstone;
                     if (level < 62) return RDM.Jolt;
-                    return RDM.Jolt2;
+                    if (level < 84) return RDM.Jolt2;
+                    return RDM.Jolt3;
                 }
                 if (actionID == RDM.Verfire)
                 {
@@ -834,7 +851,8 @@ namespace XIVComboPlugin
 
                     if (SearchBuffArray(RDM.BuffVerfireReady)) return RDM.Verfire;
                     if (level < 62) return RDM.Jolt;
-                    return RDM.Jolt2;
+                    if (level < 84) return RDM.Jolt2;
+                    return RDM.Jolt3;
                 }
             }
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -115,15 +115,16 @@ namespace XIVComboPlugin
 
             // DRAGOON
 
+            //SE built this in, so obsolete now
             // Change Jump/High Jump into Mirage Dive when Dive Ready
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonJumpFeature))
+            /*if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonJumpFeature))
                 if (actionID == DRG.Jump || actionID == DRG.HighJump)
                 {
                     if (SearchBuffArray(1243))
                         return DRG.MirageDive;
                     return iconHook.Original(self, DRG.Jump);
                 }
-
+            */
             // Replace Coerthan Torment with Coerthan Torment combo chain
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonCoerthanTormentCombo))
                 if (actionID == DRG.CTorment)
@@ -146,22 +147,34 @@ namespace XIVComboPlugin
                     if (comboTime > 0)
                     {
                         if ((lastMove == DRG.TrueThrust || lastMove == DRG.RaidenThrust) && level >= 18)
-                            return DRG.Disembowel;
-                        if (lastMove == DRG.Disembowel)
+                        {
+                            if (level >= 96)
+                                return DRG.SpiralBlow;
+                            if (level >= 18)
+                                return DRG.Disembowel;
+                        }
+                        if (lastMove == DRG.Disembowel || lastMove == DRG.SpiralBlow)
                         {
                             if (level >= 86)
                                 return DRG.ChaoticSpring;
                             if (level >= 50)
                                 return DRG.ChaosThrust;
                         }
+                        if ((lastMove == DRG.ChaosThrust || lastMove == DRG.ChaoticSpring) && level >= 58)
+                            return DRG.WheelingThrust;
+                        if ((lastMove == DRG.WheelingThrust) && level >= 64)
+                            return DRG.Drakesbane;
                     }
-                    if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
+                    //These buffs no longer exist and are now incorporated into the overall combo
+                    /*if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
                         return DRG.FangAndClaw;
                     if (SearchBuffArray(DRG.BuffWheelingThrustReady) && level >= 58)
                         return DRG.WheelingThrust;
+                    */
+                    
                     if (SearchBuffArray(DRG.BuffDraconianFire) && level >= 76)
                         return DRG.RaidenThrust;
-
+                    
                     return DRG.TrueThrust;
                 }
 
@@ -171,20 +184,32 @@ namespace XIVComboPlugin
                 {
                     if (comboTime > 0)
                     {
-                        if ((lastMove == DRG.TrueThrust || lastMove == DRG.RaidenThrust) && level >= 4)
-                            return DRG.VorpalThrust;
-                        if (lastMove == DRG.VorpalThrust)
+                        if ((lastMove == DRG.TrueThrust || lastMove == DRG.RaidenThrust) && level >= 4) 
+                        {
+                            if (level >= 96)
+                                return DRG.LanceBarrage;
+                            if (level >= 4)
+                                return DRG.VorpalThrust;
+                        }
+                        if (lastMove == DRG.VorpalThrust || lastMove == DRG.LanceBarrage)
                         {
                             if (level >= 86)
                                 return DRG.HeavensThrust;
                             if (level >= 26)
                                 return DRG.FullThrust;
                         }
+                        if ((lastMove == DRG.FullThrust || lastMove == DRG.HeavensThrust) && level >= 56)
+                            return DRG.FangAndClaw;
+                        if ((lastMove == DRG.FangAndClaw) && level >= 64)
+                            return DRG.Drakesbane;
                     }
-                    if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
+                    //These buffs no longer exist and are now incorporated into the overall combo
+                    /*if (SearchBuffArray(DRG.BuffFangAndClawReady) && level >= 56)
                         return DRG.FangAndClaw;
                     if (SearchBuffArray(DRG.BuffWheelingThrustReady) && level >= 58)
                         return DRG.WheelingThrust;
+                    */
+                    
                     if (SearchBuffArray(DRG.BuffDraconianFire) && level >= 76)
                         return DRG.RaidenThrust;
 
@@ -613,14 +638,14 @@ namespace XIVComboPlugin
             }
 
             // Ley Lines and BTL
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BlackLeyLines))
+            /*if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BlackLeyLines))
                 if (actionID == BLM.LeyLines)
                 {
                     if (SearchBuffArray(BLM.BuffLeyLines) && level >= 62)
                         return BLM.BTL;
                     return BLM.LeyLines;
                 }
-
+            */
             // ASTROLOGIAN
 
             /* Old Astro
@@ -670,13 +695,13 @@ namespace XIVComboPlugin
             // SCHOLAR
 
             // Change Fey Blessing into Consolation when Seraph is out.
-            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ScholarSeraphConsolationFeature))
+            /*if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ScholarSeraphConsolationFeature))
                 if (actionID == SCH.FeyBless)
                 {
                     if (JobGauges.Get<SCHGauge>().SeraphTimer > 0) return SCH.Consolation;
                     return SCH.FeyBless;
                 }
-
+            */
             // Change Energy Drain into Aetherflow when you have no more Aetherflow stacks.
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ScholarEnergyDrainFeature))
                 if (actionID == SCH.EnergyDrain)

--- a/XIVComboPlugin/JobActions/DRG.cs
+++ b/XIVComboPlugin/JobActions/DRG.cs
@@ -21,7 +21,11 @@
             FangAndClaw = 3554,
             WheelingThrust = 3556,
             FullThrust = 84,
-            VorpalThrust = 78;
+            VorpalThrust = 78,
+            LanceBarrage = 36901,
+            SpiralBlow = 36903,
+            Drakesbane = 36952;
+
 
         public const ushort
             BuffFangAndClawReady = 802,

--- a/XIVComboPlugin/JobActions/GNB.cs
+++ b/XIVComboPlugin/JobActions/GNB.cs
@@ -16,14 +16,18 @@
             AbdomenTear = 16157,
             EyeGouge = 16158,
             BurstStrike = 16162,
-            Hypervelocity = 25759;
+            Hypervelocity = 25759,
+            FatedCircle = 16163,
+            FatedBrand = 36936;
         public const ushort
             BuffReadyToRip = 1842,
             BuffReadyToTear = 1843,
             BuffReadyToGouge = 1844,
-            BuffReadyToBlast = 2686;
+            BuffReadyToBlast = 2686,
+            BuffReadyToRaze = 3839;
         public const byte
             LevelContinuation = 70,
-            LevelEnhancedContinuation = 86;
+            LevelEnhancedContinuation = 86,
+            LevelEnhancedContinuation2 = 96;
     }
 }

--- a/XIVComboPlugin/JobActions/MCH.cs
+++ b/XIVComboPlugin/JobActions/MCH.cs
@@ -11,6 +11,7 @@
             HeatedSlugshot = 7412,
             Hypercharge = 17209,
             HeatBlast = 7410,
+            BlazingShot = 36978,
             SpreadShot = 2870,
             AutoCrossbow = 16497,
             Scattergun = 25786;

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -14,10 +14,13 @@
             Confiteor = 16459,
             BladeOfFaith = 25748,
             BladeOfTruth = 25749,
-            BladeOfValor = 25750;
+            BladeOfValor = 25750,
+            Imperator = 36921,
+            BladeOfHonor = 36922;
 
         public const ushort
             BuffRequiescat = 1368,
-            BuffBladeOfFaithReady = 3019;
+            BuffBladeOfFaithReady = 3019,
+            BuffBladeOfHonor = 3831;
     }
 }

--- a/XIVComboPlugin/JobActions/RDM.cs
+++ b/XIVComboPlugin/JobActions/RDM.cs
@@ -17,6 +17,7 @@
             Verfire = 7510,
             Jolt = 7503,
             Jolt2 = 7524,
+            Jolt3 = 37004,
             Verholy = 7526,
             Verflare = 7525,
             Scorch = 16530,
@@ -28,6 +29,7 @@
             BuffAcceleration = 1238,
             BuffChainspell = 2560,
             BuffVerstoneReady = 1235,
-            BuffVerfireReady = 1234;
+            BuffVerfireReady = 1234,
+            BuffMagickedSwordplay = 3875;
     }
 }

--- a/XIVComboPlugin/JobActions/SAM.cs
+++ b/XIVComboPlugin/JobActions/SAM.cs
@@ -18,10 +18,13 @@
             OgiNamikiri = 25781,
             Ikishoten = 16482,
             KaeshiNamikiri = 25782,
-            Fuko = 25780;
+            Fuko = 25780,
+            Gyuofu = 36963,
+            Zanshin = 36964;
 
         public const ushort
             BuffOgiNamikiriReady = 2959,
-            BuffMeikyoShisui = 1233;
+            BuffMeikyoShisui = 1233,
+            BuffZanshinReady = 3855;
     }
 }

--- a/XIVComboPlugin/JobActions/SMN.cs
+++ b/XIVComboPlugin/JobActions/SMN.cs
@@ -15,6 +15,7 @@
             BrandOfPurgatory = 16515,
             FountainOfFire = 16514,
             Fester = 181,
+            Necrotize = 36990,
             EnergyDrain = 16508,
             Painflare = 3578,
             EnergySyphon = 16510;


### PR DESCRIPTION
Figured I'd submit the changes I made for myself. I'll try to do some more as they come up, provided a PR hasn't already been made for them.

### Changelog

**GNB**
- Added new option for Fated Circle/Brand continuation combo

**MCH**
- Added support for Blazing Shot upgrade

**RDM**
- Added support for Jolt III upgrade
- Added support for Manafication/"Magicked Swordplay" change; enchanted 123 now works properly after using.

**AST**
- Commented out AST stuff as it was causing crashes. It's defunct now anyway, so can remove\rework.