### PR TITLE
Updated GNB, RDM, MCH, BRD, disabled AST

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -162,7 +162,7 @@ namespace XIVComboPlugin
         [CustomComboInfo("Heavy Shot into Straight Shot", "Replaces Heavy Shot/Burst Shot with Straight Shot/Refulgent Arrow when procced", 23)]
         BardStraightShotUpgradeFeature = 1L << 42,
 
-        [CustomComboInfo("Quick Nock into Shadowbite", "Replaces Quick Nock/Ladonsbite with Shadowbite when procced", 23)]
+        [CustomComboInfo("Quick Nock into Wide Volley", "Replaces Quick Nock/Ladonsbite with Wide Volley/Shadowbite when procced", 23)]
         BardAoEUpgradeFeature = 1L << 59,
 
         // MONK

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -97,6 +97,9 @@ namespace XIVComboPlugin
         [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain", 37)]
         GunbreakerDemonSlaughterCombo = 1L << 22,
 
+        [CustomComboInfo("Fated Circle Continuation", "Put Continuation moves on Fated Circle when appropriate", 37)]
+        GunbreakerFatedCircleCont = 1L << 54,
+
         // MACHINIST
         [CustomComboInfo("(Heated) Shot Combo", "Replace either form of Clean Shot with its combo chain", 31)]
         MachinistMainCombo = 1L << 23,
@@ -115,8 +118,10 @@ namespace XIVComboPlugin
         BlackLeyLines = 1L << 28,
 
         // ASTROLOGIAN
+        /* Old Astro
         [CustomComboInfo("Draw on Play", "Play turns into Draw when no card is drawn, as well as the usual Play behavior", 33)]
         AstrologianCardsOnDrawFeature = 1L << 27,
+        */
 
         // SUMMONER
 

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -107,7 +107,7 @@ namespace XIVComboPlugin
         [CustomComboInfo("Spread Shot Heat", "Replace Spread Shot or Scattergun with Auto Crossbow when overheated", 31)]
         MachinistSpreadShotFeature = 1L << 24,
 
-        [CustomComboInfo("Heat Blast when overheated", "Replace Hypercharge with Heat Blast when overheated", 31)]
+        [CustomComboInfo("Heat Blast when overheated", "Replace Hypercharge with Heat Blast/Blazing Shot when overheated", 31)]
         MachinistOverheatFeature = 1L << 47,
 
         // BLACK MAGE

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -757,7 +757,7 @@ namespace XIVComboPlugin
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BardStraightShotUpgradeFeature))
                 if (actionID == BRD.HeavyShot || actionID == BRD.BurstShot)
                 {
-                    if (SearchBuffArray(BRD.BuffStraightShotReady))
+                    if (SearchBuffArray(BRD.BuffHawksEye) || SearchBuffArray(BRD.BuffBarrage))
                     {
                         if (level >= 70) return BRD.RefulgentArrow;
                         return BRD.StraightShot;
@@ -770,12 +770,14 @@ namespace XIVComboPlugin
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.BardAoEUpgradeFeature))
                 if (actionID == BRD.QuickNock || actionID == BRD.Ladonsbite)
                 {
-                    if (SearchBuffArray(BRD.BuffShadowbiteReady))
+                    if (SearchBuffArray(BRD.BuffHawksEye) || SearchBuffArray(BRD.BuffBarrage))
                     {
-                        return BRD.Shadowbite;
+                        if (level >= 72) return BRD.Shadowbite;
+                        return BRD.WideVolley;
                     }
 
-                    return iconHook.Original(self, BRD.QuickNock);
+                    if (level >= 82) return BRD.Ladonsbite;
+                    return BRD.QuickNock;
                 }
 
             // MONK

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -790,8 +790,7 @@ namespace XIVComboPlugin
             {
                 if (actionID == RDM.Veraero2)
                 {
-                    // TODO: Ideally use GrandImpactReady buff ID instead of this, so we don't have to check level
-                    if (SearchBuffArray(RDM.BuffAcceleration) && level >= 96) return RDM.GrandImpact;
+                    if (SearchBuffArray(RDM.BuffGrandImpactReady)) return RDM.GrandImpact;
 
                     if (SearchBuffArray(RDM.BuffSwiftcast) || SearchBuffArray(RDM.BuffDualcast) || 
                         SearchBuffArray(RDM.BuffAcceleration) || SearchBuffArray(RDM.BuffChainspell))
@@ -804,8 +803,7 @@ namespace XIVComboPlugin
 
                 if (actionID == RDM.Verthunder2)
                 {
-                    // TODO: Ideally use GrandImpactReady buff ID instead of this, so we don't have to check level
-                    if (SearchBuffArray(RDM.BuffAcceleration) && level >= 96) return RDM.GrandImpact;
+                    if (SearchBuffArray(RDM.BuffGrandImpactReady)) return RDM.GrandImpact;
 
                     if (SearchBuffArray(RDM.BuffSwiftcast) || SearchBuffArray(RDM.BuffDualcast) ||
                         SearchBuffArray(RDM.BuffAcceleration) || SearchBuffArray(RDM.BuffChainspell))
@@ -849,8 +847,7 @@ namespace XIVComboPlugin
                     if (level >= 80 && (lastMove == RDM.Verflare || lastMove == RDM.Verholy)) return RDM.Scorch;
                     if (level >= 90 && lastMove == RDM.Scorch) return RDM.Resolution;
 
-                    // TODO: Ideally use GrandImpactReady buff ID instead of this, so we don't have to check level
-                    if (SearchBuffArray(RDM.BuffAcceleration) && level >= 96) return RDM.GrandImpact;
+                    if (SearchBuffArray(RDM.BuffGrandImpactReady)) return RDM.GrandImpact;
 
                     if (SearchBuffArray(RDM.BuffVerstoneReady)) return RDM.Verstone;
                     if (level < 62) return RDM.Jolt;
@@ -862,8 +859,7 @@ namespace XIVComboPlugin
                     if (level >= 80 && (lastMove == RDM.Verflare || lastMove == RDM.Verholy)) return RDM.Scorch;
                     if (level >= 90 && lastMove == RDM.Scorch) return RDM.Resolution;
 
-                    // TODO: Ideally use GrandImpactReady buff ID instead of this, so we don't have to check level
-                    if (SearchBuffArray(RDM.BuffAcceleration) && level >= 96) return RDM.GrandImpact;
+                    if (SearchBuffArray(RDM.BuffGrandImpactReady)) return RDM.GrandImpact;
 
                     if (SearchBuffArray(RDM.BuffVerfireReady)) return RDM.Verfire;
                     if (level < 62) return RDM.Jolt;

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -555,10 +555,11 @@ namespace XIVComboPlugin
                 {
                     var gauge = JobGauges.Get<MCHGauge>();
                     if (gauge.IsOverheated && level >= 35)
+                    {
                         if (level >= 68)
                             return MCH.BlazingShot;
-                        else
-                            return MCH.HeatBlast;
+                        return MCH.HeatBlast;
+                    }
                     return MCH.Hypercharge;
                 }
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -785,11 +785,14 @@ namespace XIVComboPlugin
 
             // RED MAGE
 
-            // Replace Veraero/thunder 2 with Impact when Dualcast is active
+            // Replace Veraero/thunder 2 with Impact when Dualcast is active, or Grand Impact when Grand Impact Ready
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.RedMageAoECombo))
             {
                 if (actionID == RDM.Veraero2)
                 {
+                    // TODO: Ideally use GrandImpactReady buff ID instead of this, so we don't have to check level
+                    if (SearchBuffArray(RDM.BuffAcceleration) && level >= 96) return RDM.GrandImpact;
+
                     if (SearchBuffArray(RDM.BuffSwiftcast) || SearchBuffArray(RDM.BuffDualcast) || 
                         SearchBuffArray(RDM.BuffAcceleration) || SearchBuffArray(RDM.BuffChainspell))
                     {
@@ -801,6 +804,9 @@ namespace XIVComboPlugin
 
                 if (actionID == RDM.Verthunder2)
                 {
+                    // TODO: Ideally use GrandImpactReady buff ID instead of this, so we don't have to check level
+                    if (SearchBuffArray(RDM.BuffAcceleration) && level >= 96) return RDM.GrandImpact;
+
                     if (SearchBuffArray(RDM.BuffSwiftcast) || SearchBuffArray(RDM.BuffDualcast) ||
                         SearchBuffArray(RDM.BuffAcceleration) || SearchBuffArray(RDM.BuffChainspell))
                     {
@@ -835,12 +841,16 @@ namespace XIVComboPlugin
                     return RDM.Riposte;
                 }
 
+            // Replace Verstone or Verfire with Jolt if they're NOT ready, or Grand Impact when Grand Impact Ready
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.RedMageVerprocCombo))
             {
                 if (actionID == RDM.Verstone)
                 {
                     if (level >= 80 && (lastMove == RDM.Verflare || lastMove == RDM.Verholy)) return RDM.Scorch;
                     if (level >= 90 && lastMove == RDM.Scorch) return RDM.Resolution;
+
+                    // TODO: Ideally use GrandImpactReady buff ID instead of this, so we don't have to check level
+                    if (SearchBuffArray(RDM.BuffAcceleration) && level >= 96) return RDM.GrandImpact;
 
                     if (SearchBuffArray(RDM.BuffVerstoneReady)) return RDM.Verstone;
                     if (level < 62) return RDM.Jolt;
@@ -851,6 +861,9 @@ namespace XIVComboPlugin
                 {
                     if (level >= 80 && (lastMove == RDM.Verflare || lastMove == RDM.Verholy)) return RDM.Scorch;
                     if (level >= 90 && lastMove == RDM.Scorch) return RDM.Resolution;
+
+                    // TODO: Ideally use GrandImpactReady buff ID instead of this, so we don't have to check level
+                    if (SearchBuffArray(RDM.BuffAcceleration) && level >= 96) return RDM.GrandImpact;
 
                     if (SearchBuffArray(RDM.BuffVerfireReady)) return RDM.Verfire;
                     if (level < 62) return RDM.Jolt;

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -504,6 +504,18 @@ namespace XIVComboPlugin
                     return GNB.DemonSlice;
                 }
 
+            // Replace Fated Brand with Continuation
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerFatedCircleCont))
+                if (actionID == GNB.FatedCircle)
+                {
+                    if (level >= GNB.LevelEnhancedContinuation2)
+                    {
+                        if (SearchBuffArray(GNB.BuffReadyToRaze))
+                            return GNB.FatedBrand;
+                    }
+                    return GNB.FatedCircle;
+                }
+
             // MACHINIST
 
             // Replace Clean Shot with Heated Clean Shot combo
@@ -543,7 +555,10 @@ namespace XIVComboPlugin
                 {
                     var gauge = JobGauges.Get<MCHGauge>();
                     if (gauge.IsOverheated && level >= 35)
-                        return MCH.HeatBlast;
+                        if (level >= 68)
+                            return MCH.BlazingShot;
+                        else
+                            return MCH.HeatBlast;
                     return MCH.Hypercharge;
                 }
 
@@ -592,7 +607,7 @@ namespace XIVComboPlugin
 
             // ASTROLOGIAN
 
-            // Make cards on the same button as play
+            /* Old Astro
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.AstrologianCardsOnDrawFeature))
                 if (actionID == AST.Play)
                 {
@@ -615,6 +630,7 @@ namespace XIVComboPlugin
                             return AST.Draw;
                     }
                 }
+            */
 
             // SUMMONER
             // Change Fester into Energy Drain
@@ -799,19 +815,19 @@ namespace XIVComboPlugin
                     var gauge = JobGauges.Get<RDMGauge>();
                     if ((lastMove == RDM.Riposte || lastMove == RDM.ERiposte) && level >= 35)
                     {
-                        if (gauge.BlackMana >= 15 && gauge.WhiteMana >= 15)
+                        if (gauge.BlackMana >= 15 && gauge.WhiteMana >= 15 || SearchBuffArray(RDM.BuffMagickedSwordplay))
                             return RDM.EZwerchhau;
                         return RDM.Zwerchhau;
                     }
 
                     if (lastMove == RDM.Zwerchhau && level >= 50)
                     {
-                        if (gauge.BlackMana >= 15 && gauge.WhiteMana >= 15)
+                        if (gauge.BlackMana >= 15 && gauge.WhiteMana >= 15 || SearchBuffArray(RDM.BuffMagickedSwordplay))
                             return RDM.ERedoublement;
                         return RDM.Redoublement;
                     }
 
-                    if (gauge.BlackMana >= 20 && gauge.WhiteMana >= 20)
+                    if (gauge.BlackMana >= 20 && gauge.WhiteMana >= 20 || SearchBuffArray(RDM.BuffMagickedSwordplay))
                         return RDM.ERiposte;
                     return RDM.Riposte;
                 }
@@ -825,7 +841,8 @@ namespace XIVComboPlugin
 
                     if (SearchBuffArray(RDM.BuffVerstoneReady)) return RDM.Verstone;
                     if (level < 62) return RDM.Jolt;
-                    return RDM.Jolt2;
+                    if (level < 84) return RDM.Jolt2;
+                    return RDM.Jolt3;
                 }
                 if (actionID == RDM.Verfire)
                 {
@@ -834,7 +851,8 @@ namespace XIVComboPlugin
 
                     if (SearchBuffArray(RDM.BuffVerfireReady)) return RDM.Verfire;
                     if (level < 62) return RDM.Jolt;
-                    return RDM.Jolt2;
+                    if (level < 84) return RDM.Jolt2;
+                    return RDM.Jolt3;
                 }
             }
 

--- a/XIVComboPlugin/JobActions/BRD.cs
+++ b/XIVComboPlugin/JobActions/BRD.cs
@@ -11,10 +11,11 @@
             RefulgentArrow = 7409,
             QuickNock = 106,
             Ladonsbite = 25783,
+            WideVolley = 36974,
             Shadowbite = 16494;
 
         public const ushort
-            BuffStraightShotReady = 122,
-            BuffShadowbiteReady = 3002;
+            BuffHawksEye = 3861,
+            BuffBarrage = 128;
     }
 }

--- a/XIVComboPlugin/JobActions/GNB.cs
+++ b/XIVComboPlugin/JobActions/GNB.cs
@@ -16,14 +16,18 @@
             AbdomenTear = 16157,
             EyeGouge = 16158,
             BurstStrike = 16162,
-            Hypervelocity = 25759;
+            Hypervelocity = 25759,
+            FatedCircle = 16163,
+            FatedBrand = 36936;
         public const ushort
             BuffReadyToRip = 1842,
             BuffReadyToTear = 1843,
             BuffReadyToGouge = 1844,
-            BuffReadyToBlast = 2686;
+            BuffReadyToBlast = 2686,
+            BuffReadyToRaze = 3839;
         public const byte
             LevelContinuation = 70,
-            LevelEnhancedContinuation = 86;
+            LevelEnhancedContinuation = 86,
+            LevelEnhancedContinuation2 = 96;
     }
 }

--- a/XIVComboPlugin/JobActions/MCH.cs
+++ b/XIVComboPlugin/JobActions/MCH.cs
@@ -11,6 +11,7 @@
             HeatedSlugshot = 7412,
             Hypercharge = 17209,
             HeatBlast = 7410,
+            BlazingShot = 36978,
             SpreadShot = 2870,
             AutoCrossbow = 16497,
             Scattergun = 25786;

--- a/XIVComboPlugin/JobActions/RDM.cs
+++ b/XIVComboPlugin/JobActions/RDM.cs
@@ -17,6 +17,7 @@
             Verfire = 7510,
             Jolt = 7503,
             Jolt2 = 7524,
+            Jolt3 = 37004,
             Verholy = 7526,
             Verflare = 7525,
             Scorch = 16530,
@@ -28,6 +29,7 @@
             BuffAcceleration = 1238,
             BuffChainspell = 2560,
             BuffVerstoneReady = 1235,
-            BuffVerfireReady = 1234;
+            BuffVerfireReady = 1234,
+            BuffMagickedSwordplay = 3875;
     }
 }

--- a/XIVComboPlugin/JobActions/RDM.cs
+++ b/XIVComboPlugin/JobActions/RDM.cs
@@ -6,6 +6,7 @@
             Veraero2 = 16525,
             Verthunder2 = 16524,
             Impact = 16526,
+            GrandImpact = 37006,
             Redoublement = 7516,
             ERedoublement = 7529,
             Zwerchhau = 7512,

--- a/XIVComboPlugin/JobActions/RDM.cs
+++ b/XIVComboPlugin/JobActions/RDM.cs
@@ -31,6 +31,7 @@
             BuffChainspell = 2560,
             BuffVerstoneReady = 1235,
             BuffVerfireReady = 1234,
+            BuffGrandImpactReady = 3877,
             BuffMagickedSwordplay = 3875;
     }
 }


### PR DESCRIPTION
_- Re-submitting from separate branch_

Figured I'd submit the changes I made for myself. I'll try to do some more as they come up, provided a PR hasn't already been made for them.

### Changelog

**GNB**
- Added new option for Fated Circle/Brand continuation combo

**MCH**
- Added support for Blazing Shot upgrade

**RDM**
- Added support for Jolt III upgrade
- Added support for Manafication/"Magicked Swordplay" change; enchanted 123 now works properly after using.
- Added support for Grand Impact. I feel it's not necessary to include this info in the UI descriptions, as this change is simply making Square's intended functionality for Jolt & Impact compatible with the existing RDM options.

**BRD**
- Fixed procs; 7.0 combined the procs for Refulgent Arrow & Shadowbite into one, so both become "ready" via one buff.
- Barrage is also a new condition to check for, as it lets you use Refulgent Arrow & Shadowbite without the new aforementioned buff.
- Added support for Wide Volley at lvl 25 (new early version of Shadowbite).

**AST**
- Commented out AST stuff as it was causing crashes. It's defunct now anyway, so can remove\rework.