### PR TITLE
Added Viper up to level 80

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -188,6 +188,17 @@ namespace XIVComboPlugin
 
         [CustomComboInfo("Arcane Circle Combo", "Replace Arcane Circle with Plentiful Harvest while you have Immortal Sacrifice.", 39)]
         ReaperArcaneFeature = 1L << 30,
+
+        //Viper
+        [CustomComboInfo("Steel and Dread ST Combine", "Replaces Steel/Dread fang single target combo with Death Rattle when available.", 41)]
+        ViperSteelDreadSTCombine = 1L << 54,
+        [CustomComboInfo("Dreadwinter Combine", "Replaces Hunter's Coil and Swiftskin's Coil with respective Twinfang/Twinblood.", 41)]
+        ViperDreadwinderCombine = 1L << 51,
+        [CustomComboInfo("Steel and Dread AoE Combine", "Replaces Steel/Dread fang AoE combo with Last Lash when available.", 41)]
+        ViperSteelDreadAoECombine = 1L << 50,
+        [CustomComboInfo("Pit of Dread Combine", "Replaces Hunter's Coil and Swiftskin's Den with respective Twinfang/Twinblood.", 41)]
+        ViperPitOfDreadCombine = 1L << 46,
+
     }
 
     public class CustomComboInfoAttribute : Attribute

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -916,6 +916,52 @@ namespace XIVComboPlugin
                 }
             }
 
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ViperSteelDreadSTCombine))
+            {
+                if (actionID == VPR.SteelFangs || actionID == VPR.DreadFangs)
+                {
+                    if(IsAbilityUp(VPR.DeathRattle)) return VPR.DeathRattle;
+                    return iconHook.Original(self, actionID);
+                }
+            }
+
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ViperDreadwinderCombine))
+            {
+                if (actionID == VPR.HuntersCoil)
+                {
+                    if (IsAbilityUp(VPR.TwinfangBite)) return VPR.TwinfangBite;
+                    return actionID;
+                }
+                if (actionID == VPR.SwiftskinsCoil)
+                {
+                    if (IsAbilityUp(VPR.TwinbloodBite)) return VPR.TwinbloodBite;
+                    return actionID;
+                }
+            }
+
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ViperSteelDreadAoECombine))
+            {
+                if (actionID == VPR.SteelMaw || actionID == VPR.DreadMaw)
+                {
+                    if (IsAbilityUp(VPR.LastLash)) return VPR.LastLash;
+                    return iconHook.Original(self, actionID);
+                }
+            }
+
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ViperPitOfDreadCombine))
+            {
+                if (actionID == VPR.HuntersDen)
+                {   
+                    if (IsAbilityUp(VPR.TwinfangThresh)) return VPR.TwinfangThresh;
+                    return actionID;
+                }
+                if (actionID == VPR.SwiftskinDen)
+                {
+                    if (IsAbilityUp(VPR.TwinbloodThresh)) return VPR.TwinbloodThresh;
+                    return actionID;
+                }
+            }
+
             return iconHook.Original(self, actionID);
         }
 
@@ -927,6 +973,11 @@ namespace XIVComboPlugin
                 if (buffs[i].StatusId == needle)
                     return true;
             return false;
-        }        
+        }
+        private unsafe bool IsAbilityUp(uint actionID)
+        {
+            var actionManager = *ActionManager.Instance();
+            return actionManager.IsActionHighlighted(ActionType.Action, actionID);
+        }
     }
 }

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -258,6 +258,13 @@ namespace XIVComboPlugin
                 {
                     if (SearchBuffArray(PLD.BuffRequiescat) && level >= 80)
                         return iconHook.Original(self, PLD.Confiteor);
+
+                    if (SearchBuffArray(PLD.BuffBladeOfHonor)) 
+                        return PLD.BladeOfHonor;
+
+                    if (level >= 96)
+                        return PLD.Imperator;
+
                     return PLD.Requiescat;
                 }
 
@@ -330,6 +337,9 @@ namespace XIVComboPlugin
                     if (comboTime > 0)
                         if (lastMove == SAM.Hakaze && level >= 50)
                             return SAM.Yukikaze;
+
+                    if (level >= 92)
+                        return SAM.Gyuofu;
                     return SAM.Hakaze;
                 }
 
@@ -347,6 +357,8 @@ namespace XIVComboPlugin
                             return SAM.Gekko;
                     }
 
+                    if (level >= 92)
+                        return SAM.Gyuofu;
                     return SAM.Hakaze;
                 }
 
@@ -364,6 +376,8 @@ namespace XIVComboPlugin
                             return SAM.Kasha;
                     }
 
+                    if (level >= 92) 
+                        return SAM.Gyuofu;
                     return SAM.Hakaze;
                 }
 
@@ -402,7 +416,9 @@ namespace XIVComboPlugin
                         return SAM.OgiNamikiri;
                     if (JobGauges.Get<SAMGauge>().Kaeshi == Kaeshi.NAMIKIRI)
                         return SAM.KaeshiNamikiri;
-                        
+
+                    if (SearchBuffArray(SAM.BuffZanshinReady)) return SAM.Zanshin;
+
                     return SAM.Ikishoten;
                 }
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -335,8 +335,11 @@ namespace XIVComboPlugin
                     if (SearchBuffArray(SAM.BuffMeikyoShisui))
                         return SAM.Yukikaze;
                     if (comboTime > 0)
-                        if (lastMove == SAM.Hakaze && level >= 50)
+                    {
+                        if ((lastMove == SAM.Hakaze && level >= 50) || lastMove ==SAM.Gyuofu)
                             return SAM.Yukikaze;
+                    }
+
 
                     if (level >= 92)
                         return SAM.Gyuofu;
@@ -351,7 +354,7 @@ namespace XIVComboPlugin
                         return SAM.Gekko;
                     if (comboTime > 0)
                     {
-                        if (lastMove == SAM.Hakaze && level >= 4)
+                        if ((lastMove == SAM.Hakaze && level >= 4) || lastMove == SAM.Gyuofu)
                             return SAM.Jinpu;
                         if (lastMove == SAM.Jinpu && level >= 30)
                             return SAM.Gekko;
@@ -370,7 +373,7 @@ namespace XIVComboPlugin
                         return SAM.Kasha;
                     if (comboTime > 0)
                     {
-                        if (lastMove == SAM.Hakaze && level >= 18)
+                        if ((lastMove == SAM.Hakaze && level >= 18) || lastMove == SAM.Gyuofu)
                             return SAM.Shifu;
                         if (lastMove == SAM.Shifu && level >= 40)
                             return SAM.Kasha;
@@ -613,7 +616,7 @@ namespace XIVComboPlugin
                 if (actionID == AST.Play)
                 {
                     var gauge = JobGauges.Get<ASTGauge>();
-                    switch (gauge.DrawnCard)
+                    switch (gauge.DrawnCards[0])
                     {
                         case CardType.BALANCE:
                             return AST.Balance;

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -12,9 +12,7 @@
             TotalEclipse = 7381,
             Requiescat = 7383,
             Confiteor = 16459,
-            BladeOfFaith = 25748,
-            BladeOfTruth = 25749,
-            BladeOfValor = 25750;
+            BladeOfFaith = 25748;
 
         public const ushort
             BuffRequiescat = 1368,

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -14,9 +14,7 @@
             Confiteor = 16459,
             BladeOfFaith = 25748,
             BladeOfTruth = 25749,
-            BladeOfValor = 25750,
-            Imperator = 36921,
-            BladeOfHonor = 36922;
+            BladeOfValor = 25750;
 
         public const ushort
             BuffRequiescat = 1368,

--- a/XIVComboPlugin/JobActions/PLD.cs
+++ b/XIVComboPlugin/JobActions/PLD.cs
@@ -14,10 +14,13 @@
             Confiteor = 16459,
             BladeOfFaith = 25748,
             BladeOfTruth = 25749,
-            BladeOfValor = 25750;
+            BladeOfValor = 25750,
+            Imperator = 36921,
+            BladeOfHonor = 36922;
 
         public const ushort
             BuffRequiescat = 1368,
-            BuffBladeOfFaithReady = 3019;
+            BuffBladeOfFaithReady = 3019,
+            BuffBladeOfHonor = 3831;
     }
 }

--- a/XIVComboPlugin/JobActions/SAM.cs
+++ b/XIVComboPlugin/JobActions/SAM.cs
@@ -18,10 +18,13 @@
             OgiNamikiri = 25781,
             Ikishoten = 16482,
             KaeshiNamikiri = 25782,
-            Fuko = 25780;
+            Fuko = 25780,
+            Gyuofu = 36963,
+            Zanshin = 36964;
 
         public const ushort
             BuffOgiNamikiriReady = 2959,
-            BuffMeikyoShisui = 1233;
+            BuffMeikyoShisui = 1233,
+            BuffZanshinReady = 3855;
     }
 }

--- a/XIVComboPlugin/JobActions/VPR.cs
+++ b/XIVComboPlugin/JobActions/VPR.cs
@@ -3,17 +3,38 @@
     public static class VPR
     {
         public const uint
-            StormsPath = 42,
-            HeavySwing = 31,
-            Maim = 37,
-            StormsEye = 45,
-            MythrilTempest = 16462,
-            Overpower = 41,
-            InnerRelease = 7389,
-            PrimalRend = 25753,
-            Berserk = 38;
+            SteelFangs = 34606,
+            DreadFangs = 34607,
+            HuntersSting = 34608,
+            SwiftskinsSting = 34609,
+            FlankstingStrike = 34610,
+            FlanksbaneFang = 34611,
+            HindstingStrike = 34612,
+            HindsbaneFang = 34613,
+            DeathRattle = 34634,
+            Dreadwinder = 34620,
+            HuntersCoil = 34621,
+            SwiftskinsCoil = 34622,
+            TwinfangBite = 34636,
+            TwinbloodBite = 34637,
+            SerpentsTail = 35920,
+            SteelMaw = 34614,
+            DreadMaw = 34615,
+            LastLash = 34635,
+            HuntersDen = 34624,
+            SwiftskinDen = 34625,
+            TwinfangThresh = 34638,
+            TwinbloodThresh = 34639;
 
-        public const ushort
-            BuffPrimalRendReady = 2624;
+        public static class Buffs
+        {
+            public const ushort
+                Swiftscaled = 3669,
+                HuntersInstinct = 3668,
+                FlankstungVenom = 3645,
+                FlanksbaneVenom = 3646,
+                HindstungVenom = 3647,
+                HindsbaneVenom = 3648;
+        }
     }
 }

--- a/XIVComboPlugin/JobActions/VPR.cs
+++ b/XIVComboPlugin/JobActions/VPR.cs
@@ -1,0 +1,19 @@
+﻿namespace XIVComboPlugin.JobActions
+{
+    public static class VPR
+    {
+        public const uint
+            StormsPath = 42,
+            HeavySwing = 31,
+            Maim = 37,
+            StormsEye = 45,
+            MythrilTempest = 16462,
+            Overpower = 41,
+            InnerRelease = 7389,
+            PrimalRend = 25753,
+            Berserk = 38;
+
+        public const ushort
+            BuffPrimalRendReady = 2624;
+    }
+}

--- a/XIVComboPlugin/XIVComboPlugin.cs
+++ b/XIVComboPlugin/XIVComboPlugin.cs
@@ -112,6 +112,8 @@ namespace XIVComboPlugin
                 case 38: return "Dancer";
                 case 39: return "Reaper";
                 case 40: return "Sage";
+                case 41: return "Viper";
+                case 42: return "Pictomancer";
             }
         }
 


### PR DESCRIPTION
I am just doing a PR because I won't have time to work on this further. Since the new abilities don't have buff flags, I added a function called "IsAbilityUp" which checks if the ability is flagged to have "ants" around it (the yellow circling stuff).
This isn't complete but something could be useful for someone even if this PR is killed.

Also, because I didn't want to eat up too much of the (CustomComboPreset:Long) enum which can only be 63 long, I combined a few into one. Both basic ST and AoE combos result in a single ability so I put them both to just return their respective combo except if Death Rattle/Last Lash is available.

The Dreadwinder/PitOfDread should have been entries but I combined them into two.