### PR TITLE
Monk 7.0

### DIFF
--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -161,7 +161,7 @@ namespace XIVComboPlugin
         BardAoEUpgradeFeature = 1L << 59,
 
         // MONK
-        [CustomComboInfo("Monk Fury Combo", "Replaces Dragon Kick, Twin Snakes, and Demolish when Fury charges are available", 20)]
+        [CustomComboInfo("Monk Fury Combo", "Replaces Bootshine, True Strike, and Snap Punch when no Fury charges are available", 20)]
         MonkFuryCombo = 1L << 43,
 
         // RED MAGE

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -161,7 +161,8 @@ namespace XIVComboPlugin
         BardAoEUpgradeFeature = 1L << 59,
 
         // MONK
-        // you get nothing, you lose, have a nice day etc
+        [CustomComboInfo("Monk Fury Combo", "Replaces Dragon Kick, Twin Snakes, and Demolish when Fury charges are available", 20)]
+        MonkFuryCombo = 1L << 43,
 
         // RED MAGE
         [CustomComboInfo("Red Mage AoE Combo", "Replaces Veraero/thunder 2 with Impact when Dualcast or Swiftcast are active", 35)]

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -161,7 +161,7 @@ namespace XIVComboPlugin
         [CustomComboInfo("Monk Fury Combo", "Replaces Bootshine, True Strike, and Snap Punch when no Fury charges are available", 20)]
         MonkFuryCombo = 1L << 43,
 
-        [CustomComboInfo("Perfect Balance on Masterful Blitz", "Changes Masterful Blitz to Perfect Balance when no Blitz moves are available", 20)]
+        [CustomComboInfo("Perfect Balance on Masterful Blitz", "Replaces Masterful Blitz with Perfect Balance when no Blitz moves are available", 20)]
         MonkPerfectBlitz = 1L << 44,
 
         // RED MAGE

--- a/XIVComboPlugin/Configuration/CustomComboPreset.cs
+++ b/XIVComboPlugin/Configuration/CustomComboPreset.cs
@@ -161,6 +161,9 @@ namespace XIVComboPlugin
         [CustomComboInfo("Monk Fury Combo", "Replaces Bootshine, True Strike, and Snap Punch when no Fury charges are available", 20)]
         MonkFuryCombo = 1L << 43,
 
+        [CustomComboInfo("Perfect Balance on Masterful Blitz", "Changes Masterful Blitz to Perfect Balance when no Blitz moves are available", 20)]
+        MonkPerfectBlitz = 1L << 44,
+
         // RED MAGE
         [CustomComboInfo("Red Mage AoE Combo", "Replaces Veraero/thunder 2 with Impact when Dualcast or Swiftcast are active", 35)]
         RedMageAoECombo = 1L << 48,

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -785,6 +785,14 @@ namespace XIVComboPlugin
                 }
             }
 
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MonkPerfectBlitz))
+            {
+                if (actionID == MNK.MasterfulBlitz)
+                {
+                    if (JobGauges.Get<MNKGauge>().BlitzTimeRemaining <= 0 || level < 60) return MNK.PerfectBalance;
+                }
+            }
+
             // RED MAGE
 
             // Replace Veraero/thunder 2 with Impact when Dualcast is active

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -766,23 +766,21 @@ namespace XIVComboPlugin
             // MONK
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MonkFuryCombo))
             {
-                var gauge = JobGauges.Get<MNKGauge>();
-
                 if (actionID == MNK.Bootshine || actionID == MNK.LeapingOpo)
                 {
-                    if (gauge.OpoOpoFury < 1 && level >= 50) return MNK.DragonKick;
+                    if (JobGauges.Get<MNKGauge>().OpoOpoFury < 1 && level >= 50) return MNK.DragonKick;
                     return actionID;
                 }
 
                 if (actionID == MNK.TrueStrike || actionID == MNK.RisingRaptor)
                 {
-                    if (gauge.RaptorFury < 1 && level >= 18) return MNK.TwinSnakes;
+                    if (JobGauges.Get<MNKGauge>().RaptorFury < 1 && level >= 18) return MNK.TwinSnakes;
                     return actionID;
                 }
 
                 if (actionID == MNK.SnapPunch || actionID == MNK.PouncingCoeurl)
                 {
-                    if (gauge.CoeurlFury < 1 && level >= 30) return MNK.Demolish;
+                    if (JobGauges.Get<MNKGauge>().CoeurlFury < 1 && level >= 30) return MNK.Demolish;
                     return actionID;
                 }
             }

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -762,7 +762,40 @@ namespace XIVComboPlugin
                 }
 
             // MONK
-            // haha you get nothing now
+            if (Configuration.ComboPresets.HasFlag(CustomComboPreset.MonkFuryCombo))
+            {
+                var gauge = JobGauges.Get<MNKGauge>();
+
+                if (actionID == MNK.DragonKick)
+                {
+                    if (gauge.OpoOpoFury >= 1)
+                    {
+                        if (level >= 92) return MNK.LeapingOpo;
+                        return MNK.Bootshine;
+                    }
+                    return MNK.DragonKick;
+                }
+
+                if (actionID == MNK.TwinSnakes)
+                {
+                    if (gauge.RaptorFury >= 1)
+                    {
+                        if (level >= 92) return MNK.RisingRaptor;
+                        return MNK.TrueStrike;
+                    }
+                    return MNK.TwinSnakes;
+                }
+
+                if (actionID == MNK.Demolish)
+                {
+                    if (gauge.CoeurlFury >= 1)
+                    {
+                        if (level >= 92) return MNK.PouncingCoeurl;
+                        return MNK.SnapPunch;
+                    }
+                    return MNK.Demolish;
+                }
+            }
 
             // RED MAGE
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -790,6 +790,7 @@ namespace XIVComboPlugin
                 if (actionID == MNK.MasterfulBlitz)
                 {
                     if (JobGauges.Get<MNKGauge>().BlitzTimeRemaining <= 0 || level < 60) return MNK.PerfectBalance;
+                    return iconHook.Original(self, actionID);
                 }
             }
 

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -766,34 +766,22 @@ namespace XIVComboPlugin
             {
                 var gauge = JobGauges.Get<MNKGauge>();
 
-                if (actionID == MNK.DragonKick)
+                if (actionID == MNK.Bootshine || actionID == MNK.LeapingOpo)
                 {
-                    if (gauge.OpoOpoFury >= 1)
-                    {
-                        if (level >= 92) return MNK.LeapingOpo;
-                        return MNK.Bootshine;
-                    }
-                    return MNK.DragonKick;
+                    if (gauge.OpoOpoFury < 1 && level >= 50) return MNK.DragonKick;
+                    return actionID;
                 }
 
-                if (actionID == MNK.TwinSnakes)
+                if (actionID == MNK.TrueStrike || actionID == MNK.RisingRaptor)
                 {
-                    if (gauge.RaptorFury >= 1)
-                    {
-                        if (level >= 92) return MNK.RisingRaptor;
-                        return MNK.TrueStrike;
-                    }
-                    return MNK.TwinSnakes;
+                    if (gauge.RaptorFury < 1 && level >= 18) return MNK.TwinSnakes;
+                    return actionID;
                 }
 
-                if (actionID == MNK.Demolish)
+                if (actionID == MNK.SnapPunch || actionID == MNK.PouncingCoeurl)
                 {
-                    if (gauge.CoeurlFury >= 1)
-                    {
-                        if (level >= 92) return MNK.PouncingCoeurl;
-                        return MNK.SnapPunch;
-                    }
-                    return MNK.Demolish;
+                    if (gauge.CoeurlFury < 1 && level >= 30) return MNK.Demolish;
+                    return actionID;
                 }
             }
 

--- a/XIVComboPlugin/JobActions/MNK.cs
+++ b/XIVComboPlugin/JobActions/MNK.cs
@@ -17,6 +17,8 @@ namespace XIVComboPlugin.JobActions
             Demolish = 66,
             LeapingOpo = 36945,
             RisingRaptor = 36946,
-            PouncingCoeurl = 36947;
+            PouncingCoeurl = 36947,
+            PerfectBalance = 69,
+            MasterfulBlitz = 25764;
     }
 }

--- a/XIVComboPlugin/JobActions/MNK.cs
+++ b/XIVComboPlugin/JobActions/MNK.cs
@@ -9,8 +9,14 @@ namespace XIVComboPlugin.JobActions
     public static class MNK
     {
         public const uint
-            AOTD = 62,
-            FourPointFury = 16473,
-            Rockbreaker = 70;
+            Bootshine = 53,
+            TrueStrike = 54,
+            SnapPunch = 56,
+            DragonKick = 74,
+            TwinSnakes = 61,
+            Demolish = 66,
+            LeapingOpo = 36945,
+            RisingRaptor = 36946,
+            PouncingCoeurl = 36947;
     }
 }

--- a/XIVComboPlugin/XIVComboPlugin.cs
+++ b/XIVComboPlugin/XIVComboPlugin.cs
@@ -173,19 +173,6 @@ namespace XIVComboPlugin
                 }
             }
 
-            if (ImGui.CollapsingHeader("Monk"))
-            {
-                ImGui.Text("Not happening.");
-                if (ImGui.Button("External link for more detailed explanation (for real this time)"))
-                {
-                    Process.Start(new ProcessStartInfo
-                    {
-                        FileName = "https://github.com/attickdoor/XIVComboPlugin/blob/master/why-no-monk.md",
-                        UseShellExecute = true
-                    });
-                }
-            }
-
             for (var i = 0; i < orderedByClassJob.Length; i++)
             {
                 if (flagsSelected[i])


### PR DESCRIPTION
New MNK additions as discussed in https://github.com/attickdoor/XIVComboPlugin/issues/307

API was updated (at least on staging?) to include the new MNK gauge, so I went ahead and implemented MNK, if only for the sake of further discussion.

Bootshine, True Strike, and Snap Punch _**change to**_ Dragon Kick, Twin Snakes, and Demolish when no Fury charges are present. Includes lvl. 92 equivalents. 

If you wish to test it out, there's a build available over at my fork: https://github.com/Skooz/XIVComboPlugin/releases/