### PR TITLE
Monk 7.0 lvl. 92 fix

### DIFF
--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -769,19 +769,19 @@ namespace XIVComboPlugin
                 if (actionID == MNK.Bootshine || actionID == MNK.LeapingOpo)
                 {
                     if (JobGauges.Get<MNKGauge>().OpoOpoFury < 1 && level >= 50) return MNK.DragonKick;
-                    return actionID;
+                    return iconHook.Original(self, actionID);
                 }
 
                 if (actionID == MNK.TrueStrike || actionID == MNK.RisingRaptor)
                 {
                     if (JobGauges.Get<MNKGauge>().RaptorFury < 1 && level >= 18) return MNK.TwinSnakes;
-                    return actionID;
+                    return iconHook.Original(self, actionID);
                 }
 
                 if (actionID == MNK.SnapPunch || actionID == MNK.PouncingCoeurl)
                 {
                     if (JobGauges.Get<MNKGauge>().CoeurlFury < 1 && level >= 30) return MNK.Demolish;
-                    return actionID;
+                    return iconHook.Original(self, actionID);
                 }
             }
 


### PR DESCRIPTION
I actually hadn't gotten the chance to test at level 92 until now, but I should've just done this to begin with.

In short, the lvl 92 upgraded actions for Bootshine\True Strike\Snap Punch weren't working, so this fixes that.