### PR TITLE
PLD: lvl. 100 Blade of Honor fix\cleanup

### DIFF
--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -262,8 +262,7 @@ namespace XIVComboPlugin
                     if (SearchBuffArray(PLD.BuffRequiescat) && level >= 80)
                         return iconHook.Original(self, PLD.Confiteor);
 
-                    if (level >= 96) return PLD.Imperator;
-                    return PLD.Requiescat;
+                    return iconHook.Original(self, actionID);
                 }
 
             // WARRIOR


### PR DESCRIPTION
Cleanup/fix Blade of Honor not showing up on Imperator with the new action replacer settings.

Thankfully, since Blade of Honor is only usable _after_ Requiescat phase, this combo should be fine to stay as-is, unlike SAM's Ikishoten -> Ogi-Namikiri (which I saw you removed already), and WAR's IR -> Primal Rend (which might have to be removed as well).