### PR TITLE
VPR: Fix Generational Legacy

### DIFF
--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -845,32 +845,33 @@ namespace XIVComboPlugin
 
             if (Configuration.ComboPresets.HasFlag(CustomComboPreset.ViperLegacyCombo))
             {
-                switch (actionID)
-                {
-                    case VPR.SteelFangs:
-                    case VPR.SteelMaw:
-                        if (iconHook.Original(self, VPR.SerpentsTail) == VPR.FirstLegacy)
-                            return VPR.FirstLegacy;
-                        return iconHook.Original(self, actionID);
+                if (JobGauges.Get<VPRGauge>().AnguineTribute > 0)
+                    switch (actionID)
+                    {
+                        case VPR.SteelFangs:
+                        case VPR.SteelMaw:
+                            if (iconHook.Original(self, VPR.SerpentsTail) == VPR.FirstLegacy)
+                                return VPR.FirstLegacy;
+                            return iconHook.Original(self, actionID);
 
-                    case VPR.DreadFangs:
-                    case VPR.DreadMaw:
-                        if (iconHook.Original(self, VPR.SerpentsTail) == VPR.SecondLegacy)
-                            return VPR.SecondLegacy;
-                        return iconHook.Original(self, actionID);
+                        case VPR.DreadFangs:
+                        case VPR.DreadMaw:
+                            if (iconHook.Original(self, VPR.SerpentsTail) == VPR.SecondLegacy)
+                                return VPR.SecondLegacy;
+                            return iconHook.Original(self, actionID);
 
-                    case VPR.HuntersCoil:
-                    case VPR.HuntersDen:
-                        if (iconHook.Original(self, VPR.SerpentsTail) == VPR.ThirdLegacy)
-                            return VPR.ThirdLegacy;
-                        return iconHook.Original(self, actionID);
+                        case VPR.HuntersCoil:
+                        case VPR.HuntersDen:
+                            if (iconHook.Original(self, VPR.SerpentsTail) == VPR.ThirdLegacy)
+                                return VPR.ThirdLegacy;
+                            return iconHook.Original(self, actionID);
 
-                    case VPR.SwiftskinsCoil:
-                    case VPR.SwiftskinsDen:
-                        if (iconHook.Original(self, VPR.SerpentsTail) == VPR.FourthLegacy)
-                            return VPR.FourthLegacy;
-                        return iconHook.Original(self, actionID);
-                }
+                        case VPR.SwiftskinsCoil:
+                        case VPR.SwiftskinsDen:
+                            if (iconHook.Original(self, VPR.SerpentsTail) == VPR.FourthLegacy)
+                                return VPR.FourthLegacy;
+                            return iconHook.Original(self, actionID);
+                    }
             }
 
             return iconHook.Original(self, actionID);

--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -849,25 +849,25 @@ namespace XIVComboPlugin
                 {
                     case VPR.SteelFangs:
                     case VPR.SteelMaw:
-                        if (lastMove == VPR.FirstGeneration)
+                        if (iconHook.Original(self, VPR.SerpentsTail) == VPR.FirstLegacy)
                             return VPR.FirstLegacy;
                         return iconHook.Original(self, actionID);
 
                     case VPR.DreadFangs:
                     case VPR.DreadMaw:
-                        if (lastMove == VPR.SecondGeneration)
+                        if (iconHook.Original(self, VPR.SerpentsTail) == VPR.SecondLegacy)
                             return VPR.SecondLegacy;
                         return iconHook.Original(self, actionID);
 
                     case VPR.HuntersCoil:
                     case VPR.HuntersDen:
-                        if (lastMove == VPR.ThirdGeneration)
+                        if (iconHook.Original(self, VPR.SerpentsTail) == VPR.ThirdLegacy)
                             return VPR.ThirdLegacy;
                         return iconHook.Original(self, actionID);
 
                     case VPR.SwiftskinsCoil:
                     case VPR.SwiftskinsDen:
-                        if (lastMove == VPR.FourthGeneration)
+                        if (iconHook.Original(self, VPR.SerpentsTail) == VPR.FourthLegacy)
                             return VPR.FourthLegacy;
                         return iconHook.Original(self, actionID);
                 }


### PR DESCRIPTION
Seems the implementation with checking lastMove isn't working, even though it makes sense. 

Either Viper is strangely finicky with lastMove, or there's some other voodoo going on that I couldn't hope to explain. I wasn't having any luck trying to use it for my Twinfang/Twinblood suggestions, either.