### PR TITLE
PLD fix: Royal Authority Combo level sync

### DIFF
--- a/XIVComboPlugin/IconReplacer.cs
+++ b/XIVComboPlugin/IconReplacer.cs
@@ -187,7 +187,7 @@ namespace XIVComboPlugin
                 {
                     if (lastMove == PLD.FastBlade && level >= 4)
                         return PLD.RiotBlade;
-                    if (lastMove == PLD.RiotBlade)
+                    if (lastMove == PLD.RiotBlade && level >= 26)
                         return iconHook.Original(self, PLD.RageOfHalone);
                     return PLD.FastBlade;
                 }


### PR DESCRIPTION
`Royal Authority Combo` wasn't working when level was synced below 26. Combo chain would show `Rage of Halone` as next step, even though that action isn't available below level 26, leading to soft-locking the combo on an inaccessible step until the combo timer resets.